### PR TITLE
Grab access token and inject as header into API calls

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -72,3 +72,23 @@ Check that the bindings for https settings are for port 44364 (you may need to r
 
 * https://signin-test-sup-as.azurewebsites.net/users/80BA7FAF-D6E1-47B4-9EDD-4539F53C8B9E/audit - The data
   here is always 15 mins out of date as its on an event stream (its more realtime in prod envs.)
+
+### Additional Msbuild Target
+
+The default value of `InputSwaggerJson` is `manage-courses-api-swagger.json`.
+The default value of `OutputSwaggerGeneration` is `Generated\ManageCoursesApiClient.cs`
+
+```bash
+msbuild
+```
+
+```bash
+msbuild /p:InputSwaggerJson={url to json| file path to json}
+```
+
+For development or previewing
+The default value is `Generated\ManageCoursesApiClient.cs`
+```bash
+cd src\api-client
+msbuild /t:NSwag /p:OutputSwaggerGeneration={file path}
+```

--- a/src/api-client/ApiClient.csproj
+++ b/src/api-client/ApiClient.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/api-client/ApiClient.csproj
+++ b/src/api-client/ApiClient.csproj
@@ -17,7 +17,7 @@
 
     <PropertyGroup>
       <classname>ManageCoursesApiClient</classname>
-      <namespace>$(RootNamespace).Generated</namespace>
+      <namespace>$(RootNamespace)</namespace>
     </PropertyGroup>
 
     <Exec Command="$(NSwagExe_Core20) swagger2csclient /input:$(InputSwaggerJson) /output:$(OutputSwaggerGeneration) /classname:$(classname) /namespace:$(namespace)" />

--- a/src/api-client/ApiClient.csproj
+++ b/src/api-client/ApiClient.csproj
@@ -10,7 +10,17 @@
 
   <Target Name="NSwag" BeforeTargets="Compile">
     <Copy SourceFiles="@(Reference)" DestinationFolder="$(OutDir)References" />
-    <Exec Command="$(NSwagExe_Core20) swagger2csclient /input:manage-courses-api-swagger.json /classname:ManageCoursesApiClient /namespace:GovUk.Education.ManageCourses.ApiClient.Generated /output:Generated\ManageCoursesApiClient.cs" />
+    <PropertyGroup>
+      <InputSwaggerJson Condition="$(InputSwaggerJson) == ''">manage-courses-api-swagger.json</InputSwaggerJson>
+      <OutputSwaggerGeneration Condition="$(OutputSwaggerGeneration) == ''">Generated\ManageCoursesApiClient.cs</OutputSwaggerGeneration>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <classname>ManageCoursesApiClient</classname>
+      <namespace>$(RootNamespace).Generated</namespace>
+    </PropertyGroup>
+
+    <Exec Command="$(NSwagExe_Core20) swagger2csclient /input:$(InputSwaggerJson) /output:$(OutputSwaggerGeneration) /classname:$(classname) /namespace:$(namespace)" />
     <RemoveDir Directories="$(OutDir)References" />
   </Target>
 

--- a/src/api-client/ApiClient.csproj
+++ b/src/api-client/ApiClient.csproj
@@ -18,9 +18,11 @@
     <PropertyGroup>
       <classname>ManageCoursesApiClient</classname>
       <namespace>$(RootNamespace)</namespace>
+      <clientBaseClass>$(namespace).ManageCoursesApiClientBase</clientBaseClass>
+      <configurationClass>$(namespace).IManageCoursesApiClientConfiguration</configurationClass>
     </PropertyGroup>
 
-    <Exec Command="$(NSwagExe_Core20) swagger2csclient /input:$(InputSwaggerJson) /output:$(OutputSwaggerGeneration) /classname:$(classname) /namespace:$(namespace)" />
+    <Exec Command="$(NSwagExe_Core20) swagger2csclient /input:$(InputSwaggerJson) /output:$(OutputSwaggerGeneration) /classname:$(classname) /namespace:$(namespace) /clientBaseClass:$(clientBaseClass) /configurationClass:$(configurationClass)" />
     <RemoveDir Directories="$(OutDir)References" />
   </Target>
 

--- a/src/api-client/Generated/ManageCoursesApiClient.cs
+++ b/src/api-client/Generated/ManageCoursesApiClient.cs
@@ -4,7 +4,7 @@
 // </auto-generated>
 //----------------------
 
-namespace GovUk.Education.ManageCourses.ApiClient.Generated
+namespace GovUk.Education.ManageCourses.ApiClient
 {
     #pragma warning disable // Disable all warnings
 

--- a/src/api-client/Generated/ManageCoursesApiClient.cs
+++ b/src/api-client/Generated/ManageCoursesApiClient.cs
@@ -9,12 +9,12 @@ namespace GovUk.Education.ManageCourses.ApiClient
     #pragma warning disable // Disable all warnings
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "11.17.13.0 (NJsonSchema v9.10.50.0 (Newtonsoft.Json v9.0.0.0))")]
-    public partial class ManageCoursesApiClient 
+    public partial class ManageCoursesApiClient : GovUk.Education.ManageCourses.ApiClient.ManageCoursesApiClientBase
     {
         private string _baseUrl = "http://localhost:6001";
         private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings;
     
-        public ManageCoursesApiClient()
+        public ManageCoursesApiClient(GovUk.Education.ManageCourses.ApiClient.IManageCoursesApiClientConfiguration configuration) : base(configuration)
         {
             _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(() => 
             {

--- a/src/api-client/IManageCoursesApiClientConfiguration.cs
+++ b/src/api-client/IManageCoursesApiClientConfiguration.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace GovUk.Education.ManageCourses.ApiClient
+{
+    public interface IManageCoursesApiClientConfiguration
+    {
+        Task<string> GetAccessTokenAsync();
+    }
+}

--- a/src/api-client/ManageApi.cs
+++ b/src/api-client/ManageApi.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ManageCourses.ApiClient;
-using Microsoft.Extensions.Configuration;
 
 namespace GovUk.Education.ManageCourses.ApiClient
 {
@@ -11,18 +9,9 @@ namespace GovUk.Education.ManageCourses.ApiClient
     {
         private readonly ManageCoursesApiClient _apiClient;
 
-        public ManageApi(IConfiguration configuration)
+        public ManageApi(ManageCoursesApiClient apiClient)
         {
-            const string key = "ApiConnection:Url";
-            var baseUrl = configuration[key];
-            if (string.IsNullOrWhiteSpace(baseUrl))
-            {
-                throw new Exception("Missing configuration for " + key);
-            }
-            _apiClient = new ManageCoursesApiClient
-            {
-                BaseUrl = baseUrl
-            };
+            _apiClient = apiClient;
         }
 
         public async Task<IEnumerable<Course>> GetCourses()

--- a/src/api-client/ManageApi.cs
+++ b/src/api-client/ManageApi.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ManageCourses.ApiClient.Generated;
+using GovUk.Education.ManageCourses.ApiClient;
 using Microsoft.Extensions.Configuration;
 
 namespace GovUk.Education.ManageCourses.ApiClient

--- a/src/api-client/ManageCoursesApiClient.cs
+++ b/src/api-client/ManageCoursesApiClient.cs
@@ -1,0 +1,13 @@
+﻿using System.Net.Http.Headers;
+
+namespace GovUk.Education.ManageCourses.ApiClient
+{
+    public partial class ManageCoursesApiClient
+    {
+        partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url)
+        {
+            var accessToken = ApiClientConfiguration.GetAccessTokenAsync().Result;
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        }
+    }
+}

--- a/src/api-client/ManageCoursesApiClientBase.cs
+++ b/src/api-client/ManageCoursesApiClientBase.cs
@@ -1,0 +1,12 @@
+﻿namespace GovUk.Education.ManageCourses.ApiClient
+{
+    public class ManageCoursesApiClientBase
+    {
+        protected readonly IManageCoursesApiClientConfiguration ApiClientConfiguration;
+
+        public ManageCoursesApiClientBase(IManageCoursesApiClientConfiguration apiClientConfiguration)
+        {
+            ApiClientConfiguration = apiClientConfiguration;
+        }
+    }
+}

--- a/src/ui/ManageCoursesApiClientConfiguration.cs
+++ b/src/ui/ManageCoursesApiClientConfiguration.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using GovUk.Education.ManageCourses.ApiClient;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+
+namespace GovUk.Education.ManageCourses.Ui
+{
+
+    public class ManageCoursesApiClientConfiguration : IManageCoursesApiClientConfiguration
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        public ManageCoursesApiClientConfiguration(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async Task<string> GetAccessTokenAsync()
+        {
+            return await _httpContextAccessor.HttpContext.GetTokenAsync("access_token");
+        }
+    }
+}

--- a/src/ui/ManageCoursesConfig.cs
+++ b/src/ui/ManageCoursesConfig.cs
@@ -25,5 +25,7 @@ namespace GovUk.Education.ManageCourses.Ui
         public string RegisterBaseUrl => _configuration["url:register"];
 
         public string ExternalRegistrationUrl => $"{RegisterBaseUrl}?client_id={ClientId}&redirect_uri={SiteBaseUrl}/{RegisterCallbackPath}";
+
+        public string ApiUrl => _configuration["ApiConnection:Url"];
     }
 }

--- a/src/ui/Startup.cs
+++ b/src/ui/Startup.cs
@@ -31,7 +31,7 @@ namespace GovUk.Education.ManageCourses.Ui
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc();
-            const string envKeyApiConnection = "ApiConnection:Uri";            
+            const string envKeyApiConnection = "ApiConnection:Uri";
             var apiUri = Configuration[envKeyApiConnection];
             _logger.LogInformation("Using API base URL: " + apiUri);
             //services.AddScoped<IManageCoursesApi>(provider => new IManageCoursesApi(new HttpClient(), apiUri));

--- a/src/ui/Startup.cs
+++ b/src/ui/Startup.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using GovUk.Education.ManageCourses.ApiClient;
-using GovUk.Education.ManageCourses.ApiClient.Generated;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;

--- a/src/ui/Startup.cs
+++ b/src/ui/Startup.cs
@@ -73,9 +73,21 @@ namespace GovUk.Education.ManageCourses.Ui
                 };
                 options.DisableTelemetry = true;
             });
+
+            services.AddSingleton<IManageCoursesApiClientConfiguration, ManageCoursesApiClientConfiguration>();
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddSingleton<ManageCoursesConfig, ManageCoursesConfig>();
             services.AddSingleton<ManageApi, ManageApi>();
-            }
+            services.AddSingleton(serviceProvider =>
+            {
+                var manageCoursesApiClientConfiguration = serviceProvider.GetService<IManageCoursesApiClientConfiguration>();
+                var manageCoursesApiClient = new ManageCoursesApiClient(manageCoursesApiClientConfiguration);
+                var config = serviceProvider.GetService<ManageCoursesConfig>();
+                manageCoursesApiClient.BaseUrl = config.ApiUrl;
+                return manageCoursesApiClient;
+            });
+        }
+
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, IServiceProvider serviceProvider)

--- a/src/ui/Views/_ViewImports.cshtml
+++ b/src/ui/Views/_ViewImports.cshtml
@@ -1,3 +1,3 @@
-@using GovUk.Education.ManageCourses.ApiClient.Generated
+@using GovUk.Education.ManageCourses.ApiClient
 @using GovUk.Education.ManageCourses.Ui.ViewModels
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
This mostly @defong 's work; tidied up and fixed-up for latest master code.

The calls to the API are still working, and I can see the extracted token while debugging before it's injected into the API call. I think this is good to go into master.