### PR TITLE
Three small copy tweaks

### DIFF
--- a/src/ui/Views/Course/Variants.cshtml
+++ b/src/ui/Views/Course/Variants.cshtml
@@ -71,5 +71,5 @@
 </table>
 
 <p>
-    <a href="@link">Contact Becoming a Teacher Team to report a problem</a>
+    <a href="@link">Contact the Becoming a Teacher team to report a problem</a>
 </p>

--- a/src/ui/Views/Courses/Index.cshtml
+++ b/src/ui/Views/Courses/Index.cshtml
@@ -26,7 +26,7 @@
             We found @Model.TotalCount courses belonging to @Model.Courses.OrganisationName.
         </p>
         <p>
-            Check that your course information is correct. If there are any problems, you should contact <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Publish%20teacher%20training%20courses%20problem">Become a Teacher</a> to let us know.
+            Check that your course information is correct. If there are any problems, you should <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Publish%20teacher%20training%20courses%20problem">contact the Becoming a Teacher team</a> to let us know.
         </p>
         <p>
             To make any changes, for now you’ll still need to use UCAS web-link. Changes on UCAS will normally show here within one working day.

--- a/src/ui/Views/Home/Imported.cshtml
+++ b/src/ui/Views/Home/Imported.cshtml
@@ -12,7 +12,7 @@
 
       <p>We found @Model.TotalCount courses belonging to @Model.OrganisationName.</p>
 
-      <p>Check that your course information is correct. If there are any mistakes, you should contact the Becoming a Teacher team to let us know.</p>
+      <p>Check that your course information is correct. If there are any problems, you should contact the Becoming a Teacher team to let us know.</p>
       <p>To make any changes, for now you’ll still need to use UCAS web-link. Changes on UCAS will normally show here within one working day. </p>
 
       <p>Soon you’ll be able to add extra content to tell applicants more about you and your courses.</p>


### PR DESCRIPTION
* Include contact in email link to be explicit
* Replace "mistakes" with "problems", a problem may not be a mistake
* It's "Becoming a Teacher team", not become a teacher, and team is not capitalised