### PR TITLE
Add copy about future features

### DIFF
--- a/src/ui/Views/Courses/Index.cshtml
+++ b/src/ui/Views/Courses/Index.cshtml
@@ -31,6 +31,12 @@
         <p>
             To make any changes, for now you’ll still need to use UCAS web-link. Changes on UCAS will normally show here within one working day.
         </p>
+        <p>
+            Soon you’ll be able to add extra content to tell applicants more about you and your courses.
+        </p>
+        <p>
+            In the future, you’ll be able to edit all course information here.
+        </p>
     </div>
 </div>
 


### PR DESCRIPTION
### Context

On the `we imported` page, which we aren't using (see https://manage-courses-prototype.herokuapp.com/history/check-ucas-data), we hinted that further fields would be available soon, and that in the future UCAS would go away.

### Changes proposed in this pull request

We need to echo that text in the "Check courses" section to set the right context for users.
