### PR TITLE
Added the pdf to courses listing page

### DIFF
--- a/src/ui/Views/Courses/Index.cshtml
+++ b/src/ui/Views/Courses/Index.cshtml
@@ -32,7 +32,7 @@
             To make any changes, for now you’ll still need to use UCAS web-link. Changes on UCAS will normally show here within one working day.
         </p>
         <p>
-            Soon you’ll be able to add extra content to tell applicants more about you and your courses.
+            Soon you’ll be able to add extra content to tell applicants more about you and your courses. <a href="https://afdebatmanageui.blob.core.windows.net/public-assets/How%20to%20prepare%20the%20rest%20of%20your%20course%20information.pdf">Find out more about this here</a>.
         </p>
         <p>
             In the future, you’ll be able to edit all course information here.


### PR DESCRIPTION
### Context
A link of the guidance pdf is needed for the provider.

### Changes proposed in this pull request
 Add the pdf as a link on the courses listing page

### Guidance to review

#### New 
![image](https://user-images.githubusercontent.com/470137/42333954-0c8bcfe6-8074-11e8-8de3-60fd47f5f98a.png)
![image](https://user-images.githubusercontent.com/470137/42334285-d1c614e2-8074-11e8-9b8c-173d259942ee.png)

#### Old
![image](https://user-images.githubusercontent.com/470137/42334211-a091d3f2-8074-11e8-9d86-bc42ab00dae5.png)
