### PR TITLE
Home link should go to root not courses

### DIFF
--- a/src/ui/Views/Shared/_Layout.cshtml
+++ b/src/ui/Views/Shared/_Layout.cshtml
@@ -35,7 +35,7 @@
         <div class="content">
             <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
             <nav id="proposition-menu">
-                <a href="/courses" id="proposition-name" role="link">@ViewData["serviceName"]</a>
+                <a href="/" id="proposition-name" role="link">@ViewData["serviceName"]</a>
 
                 <ul id="proposition-links">
                     @if (User.Identity.IsAuthenticated)


### PR DESCRIPTION
### Context
Header service link goes to 404

### Changes proposed in this pull request
Update service link in header to go to`/` not `/courses`

### Guidance to review
Login as Tim, click “Publish teacher training courses” in the header