### PR TITLE
Removed course title from url

### DIFF
--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -20,8 +20,8 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         {
             _manageApi = manageApi;
         }
-        [Route("{instCode}/course/{accreditingProviderId=self}/{courseTitle}/{ucasCode}")]
-        public async Task<IActionResult> Variants(string instCode, string accreditingProviderId, string courseTitle, string ucasCode)
+        [Route("{instCode}/course/{accreditingProviderId=self}/{ucasCode}")]
+        public async Task<IActionResult> Variants(string instCode, string accreditingProviderId, string ucasCode)
         {
             var course = await _manageApi.GetCoursesByOrganisation(instCode);
 
@@ -29,12 +29,12 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                 ? course.ProviderCourses.First(c => String.IsNullOrEmpty(c.AccreditingProviderId))
                 : course.ProviderCourses
                     .First(c => c.AccreditingProviderId.Equals(accreditingProviderId, StringComparison.InvariantCultureIgnoreCase));
+            var courseDetail = providerCourse.CourseDetails.First(x => x.Variants.Select(v => v.UcasCode == ucasCode).Any());
 
-            var courseDetail = providerCourse.CourseDetails.First(x => x.CourseTitle.Equals(courseTitle, StringComparison.InvariantCultureIgnoreCase));
             var variant = courseDetail.Variants.FirstOrDefault(v => v.UcasCode == ucasCode);
             if (variant == null) return null;
 
-            var subjects = variant.Subjects.Count() > 0 ? variant.Subjects.Aggregate((current, next) => current + ", " + next) : "";
+            var subjects = variant.Subjects.Any() ? variant.Subjects.Aggregate((current, next) => current + ", " + next) : "";
 
             var courseVariant =
                 new CourseVariantViewModel
@@ -74,7 +74,9 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                         };
                     })
                 };
+
             var orgs = await _manageApi.GetOrganisations();
+
             var viewModel = new FromUcasViewModel
             {
                 OrganisationName = course.OrganisationName,
@@ -87,6 +89,5 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
 
             return View(viewModel);
         }
-
     }
 }

--- a/src/ui/Views/Courses/Index.cshtml
+++ b/src/ui/Views/Courses/Index.cshtml
@@ -84,7 +84,7 @@
                 <td>@variant.UcasCode</td>
                 <td>@variant.GetCourseVariantType()</td>
                 <td class="ucas-view-link">
-                    <a href="@Url.Action("variants", "course", new { instCode = Model.Courses.UcasCode, accreditingProviderId = providerCourse.AccreditingProviderId, courseTitle = course.CourseTitle, ucasCode = variant.UcasCode })">View course</a>
+                    <a href="@Url.Action("variants", "course", new { instCode = Model.Courses.UcasCode, accreditingProviderId = providerCourse.AccreditingProviderId, ucasCode = variant.UcasCode })">View course</a>
                 </td>
             </tr>
                 }


### PR DESCRIPTION
### Context
The url for the course page contained the course title:
`/organisation/25W/course/N55/Physical%20Education/2NNM` 
### Changes proposed in this pull request
Remove the course title and just have the ucas code:
 `/organisation/25W/course/2NNM`

### Guidance to review
In the course controller the 'Variants' end point originally looked for the course title existing in the providerCourse.CourseDetails object.
Now it looks for the UcasCode existing in the variants collection in the CourseDatails object.

The Courses list page (index) neede to be updated to the new Url
