### PR TITLE
Added dotnet watch

### DIFF
--- a/ManageCoursesUi.Tests/ManageCoursesUi.Tests.csproj
+++ b/ManageCoursesUi.Tests/ManageCoursesUi.Tests.csproj
@@ -11,7 +11,11 @@
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ui/ManageCoursesUi.csproj
+++ b/src/ui/ManageCoursesUi.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.2" />
+    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Context
You can now work faster and fail even faster

Add dotnet watch
Most `dotnet [cmd]` can be replaced with `dotnet watch [cmd]`

### Changes proposed in this pull request
Added dotnet watch for CLI

### Guidance to review
https://docs.microsoft.com/en-us/aspnet/core/tutorials/dotnet-watch?view=aspnetcore-2.1

PS X:\repos\dfe\manage-courses-ui> `dotnet restore`
PS X:\repos\dfe\manage-courses-ui> `cd .\src\ui\`
PS X:\repos\dfe\manage-courses-ui\src\ui> `dotnet watch run`
PS X:\repos\dfe\manage-courses-ui\src\ui> `..\..\ManageCoursesUi.Tests\`
PS X:\repos\dfe\manage-courses-ui\ManageCoursesUi.Tests> `dotnet restore`
PS X:\repos\dfe\manage-courses-ui\ManageCoursesUi.Tests> `dotnet watch test`
