### PR TITLE
Made changes to the ManageApi to reflect the new Api endpoint.

### DIFF
--- a/src/ui/ManageApi.cs
+++ b/src/ui/ManageApi.cs
@@ -31,7 +31,7 @@ namespace GovUk.Education.ManageCourses.Ui
 
         public async Task<IEnumerable<UserOrganisation>> GetOrganisations()
         {
-            var orgs = await _apiClient.Organisations_GetAsync();
+            var orgs = await _apiClient.Organisations_GetAllAsync();
             return orgs;
         }
 

--- a/src/ui/ManageCoursesUi.csproj
+++ b/src/ui/ManageCoursesUi.csproj
@@ -24,7 +24,7 @@
   <Import Condition="Exists('$(ProjectDir)dev.targets')" Project="$(ProjectDir)dev.targets" />
   
   <ItemGroup Condition="Exists('$(ProjectDir)dev.targets')==false">
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.1.1.*" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="1.1.0" />
   </ItemGroup>
 
   <!--<Target Name="Grunt" Condition="'$(Configuration)'=='Release'" BeforeTargets="AfterBuild">

--- a/src/ui/Views/Organisations/Index.cshtml
+++ b/src/ui/Views/Organisations/Index.cshtml
@@ -15,7 +15,7 @@
           <li>
             <h3 class="govuk-heading-m">
               <a href="@Url.Action("Courses", "Organisation", new {ucasCode = organisation.UcasCode})" class="govuk-link">@organisation.OrganisationName</a>
-              <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block">@organisation.TotalCourses courses</span>
+              @*<span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block">@organisation.TotalCourses courses</span>*@
             </h3>
           </li>
         }


### PR DESCRIPTION
The Api endpoint to retrieve organisations for a user has been refactored.
Changes were made to the ManageApi class in order to consume the correct new endpoint.
However!
The total courses for each organisation is now displaying correctly but differs from the existing code that displays the courses as the user drills into the organisation.
The total courses field has been temporarily commented out on the Organisations view

### Context

### Changes proposed in this pull request

### Guidance to review
