### PR TITLE
Connect to new api endpoints

### DIFF
--- a/ManageCoursesUi.Tests/Controllers/OrganisationControllerTests.cs
+++ b/ManageCoursesUi.Tests/Controllers/OrganisationControllerTests.cs
@@ -26,16 +26,17 @@ namespace ManageCoursesUi.Tests
             var organisationName = "organisationName";
             var currentTab = "courses";
             // Todo: fix this ObservableCollection.
-            var orgCourses = new OrganisationCourses
+            var instCourses = new InstitutionCourses
             {
-                UcasCode = ucasCode,
-                ProviderCourses = new ObservableCollection<ProviderCourse>
-                { new ProviderCourse
-                { CourseDetails = new ObservableCollection<CourseDetail>
-                { new CourseDetail
-                { Variants = new ObservableCollection<CourseVariant>
-                { new CourseVariant
-                { UcasCode = ucasCode } } } } } }
+                InstitutionCode = ucasCode,
+                InstitutionName = organisationName,
+                Courses = new ObservableCollection<Course>
+                {
+                    new Course
+                    {
+                        InstCode = ucasCode
+                    }
+                }
             };
             var orgs = new List<UserOrganisation> {
                 new UserOrganisation(), new UserOrganisation {
@@ -44,11 +45,9 @@ namespace ManageCoursesUi.Tests
             };
 
             var apiMock = new Mock<IManageApi>();
-            apiMock.Setup(x => x.GetCoursesByOrganisation(ucasCode))
-                .ReturnsAsync(orgCourses);
+            apiMock.Setup(x => x.GetCoursesByOrganisation(ucasCode)).ReturnsAsync(instCourses);
 
-            apiMock.Setup(x => x.GetOrganisations())
-                .ReturnsAsync(orgs);
+            apiMock.Setup(x => x.GetOrganisations()).ReturnsAsync(orgs);
 
             var controller = new OrganisationController(apiMock.Object);
 
@@ -58,8 +57,9 @@ namespace ManageCoursesUi.Tests
 
             Assert.IsNotNull(viewResult);
             var model = viewResult.ViewData.Model as CourseListViewModel;
-            Assert.AreEqual(orgCourses, model.Courses);
-            Assert.AreEqual(1, model.TotalCount);
+
+            Assert.NotNull(model);
+            Assert.AreEqual(1, model.Providers.Count);
 
             var tabViewModel = model.TabViewModel;
             Assert.AreEqual(currentTab, tabViewModel.CurrentTab);

--- a/ManageCoursesUi.Tests/Helpers/TestHelper.cs
+++ b/ManageCoursesUi.Tests/Helpers/TestHelper.cs
@@ -21,7 +21,7 @@ namespace ManageCoursesUi.Tests.Helpers
 
         private static string _courseTitles = "Maths,Chemistry,Biology,Music,Languages";
 
-        public static OrganisationCourses GetTestData(EnumDataType dataType, string accreditedProviderId, string accreditedProviderName)
+        public static InstitutionCourses GetTestData(EnumDataType dataType, string accreditedProviderId, string accreditedProviderName)
         {
             return GenerateData(dataType, accreditedProviderId, accreditedProviderName);
         }
@@ -34,22 +34,24 @@ namespace ManageCoursesUi.Tests.Helpers
         /// <param name="accreditedProviderId">used to setup the providerCourse object</param>
         /// <param name="accreditedProviderName">used to setup the providerCourse object</param>
         /// <returns></returns>
-        private static OrganisationCourses GenerateData(EnumDataType dataType, string accreditedProviderId, string accreditedProviderName)
+        private static InstitutionCourses GenerateData(EnumDataType dataType, string accreditedProviderId, string accreditedProviderName)
         {
-            var testData = new OrganisationCourses
+            var testData = new InstitutionCourses
             {
-                OrganisationId = OrganisationId,
-                OrganisationName = OrganisationName,
-                UcasCode = TargetedUcasCode,
-                ProviderCourses = new ObservableCollection<ProviderCourse>
-                {
-                    new ProviderCourse
-                    {
-                        AccreditingProviderId = accreditedProviderId,
-                        AccreditingProviderName = accreditedProviderName,
-                        CourseDetails = new ObservableCollection<CourseDetail>(GenerateCourseDetails(dataType))
-                    }
-                }
+                InstitutionCode = OrganisationId,
+                InstitutionName = OrganisationName,
+                Courses = new ObservableCollection<Course>(GenerateCourseDetails(dataType))
+                    
+                //UcasCode = TargetedUcasCode,
+                //ProviderCourses = new ObservableCollection<ProviderCourse>
+                //{
+                //    new ProviderCourse
+                //    {
+                //        AccreditingProviderId = accreditedProviderId,
+                //        AccreditingProviderName = accreditedProviderName,
+                //        CourseDetails = new ObservableCollection<CourseDetail>(GenerateCourseDetails(dataType))
+                //    }
+                //}
             };
 
             return testData;
@@ -59,9 +61,9 @@ namespace ManageCoursesUi.Tests.Helpers
         /// </summary>
         /// <param name="type">The type of test data that needs to be generated</param>
         /// <returns></returns>
-        private static List<CourseDetail> GenerateCourseDetails(EnumDataType type)
+        private static List<Course> GenerateCourseDetails(EnumDataType type)
         {
-            var listToReturn = new List<CourseDetail>();            
+            var listToReturn = new List<Course>();            
             int variantCount;
             bool happyPath;
             switch (type)
@@ -91,14 +93,7 @@ namespace ManageCoursesUi.Tests.Helpers
 
             foreach (var courseTitle in _courseTitles.Split(","))
             {
-                listToReturn.Add(
-                    new CourseDetail
-                    {
-                        AgeRange = "S",
-                        CourseTitle = courseTitle,
-                        Variants = new ObservableCollection<CourseVariant>(GenerateCourseVariants(variantCount, (courseTitle == TargetedCourseTitle && happyPath), courseTitle))
-                    }
-                );
+                listToReturn.AddRange(GenerateCourseVariants(variantCount, (courseTitle == TargetedCourseTitle && happyPath), courseTitle));
             }
 
             return listToReturn;
@@ -111,9 +106,9 @@ namespace ManageCoursesUi.Tests.Helpers
         /// <param name="happyPath">If true it sets the Ucas code to the targeted ucas code for one variant</param>
         /// <param name="courseTitle">For the variant course name</param>
         /// <returns></returns>
-        private static List<CourseVariant> GenerateCourseVariants(int count, bool happyPath, string courseTitle)
+        private static List<Course> GenerateCourseVariants(int count, bool happyPath, string courseTitle)
         {
-            var listToReturn = new List<CourseVariant>();
+            var listToReturn = new List<Course>();
 
             for (var counter = 1; counter <= count; counter++)
             {                
@@ -128,26 +123,21 @@ namespace ManageCoursesUi.Tests.Helpers
                     ucasCode += counter;
                 }
                 listToReturn.Add(
-                    new CourseVariant
+                    new Course
                     {
                         StudyMode = "F",
-                        ProfPostFlag = "",
+                        ProfpostFlag = "",
                         ProgramType = "SC",
-                        Subjects = new ObservableCollection<string>
-                        {
-                            courseTitle,
-                            "Secondary"
-                        },
+                        Subjects = courseTitle + ",Secondary",
                         CourseCode = ucasCode,
                         Name = courseTitle,
-                        UcasCode = ucasCode,
-                        Campuses = new ObservableCollection<Campus>
+                        InstCode = ucasCode,
+                        Schools = new ObservableCollection<School>
                         {
-                            new Campus
+                            new School
                             {
-                                CourseOpenDate = "2018-10-16 00:00:00",
+                                ApplicationsAcceptedFrom = "2018-10-16 00:00:00",
                                 Code = TargetedUcasCode,
-                                Name = courseTitle,
                                 Address1 = "address1",
                                 Address2 = "address2",
                                 Address3 = "address3",

--- a/src/ui/Helpers/ViewModelHelpers.cs
+++ b/src/ui/Helpers/ViewModelHelpers.cs
@@ -9,6 +9,15 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
 {
     public static class ViewModelHelpers
     {
+        public static string GetCourseVariantType(this Course course)
+        {
+            var result = string.IsNullOrWhiteSpace(course.ProfpostFlag) ? "QTS " : "PGCE with QTS ";
+
+            result += course.StudyMode.Equals("F", StringComparison.InvariantCultureIgnoreCase) ? "full time" : "part time";
+            result += course.ProgramType.Equals("SS", StringComparison.InvariantCultureIgnoreCase) ? " with salary" : "";
+
+            return result;
+        }
         public static string GetCourseVariantType(this CourseVariant courseVariant)
         {
             var result = string.IsNullOrWhiteSpace(courseVariant.ProfPostFlag) ? "QTS " : "PGCE with QTS ";

--- a/src/ui/IManageApi.cs
+++ b/src/ui/IManageApi.cs
@@ -10,8 +10,10 @@ namespace GovUk.Education.ManageCourses.Ui
 {
     public interface IManageApi
     {
-        Task<OrganisationCourses> GetCoursesByOrganisation(string ucasCode);
+        Task<InstitutionCourses> GetCoursesByOrganisation(string ucasCode);
+        Task<Course> GetCourseByUcasCode(string instCode, string ucasCode);
         Task<IEnumerable<UserOrganisation>> GetOrganisations();
+        Task<UserOrganisation> GetOrganisation(string instCode);
         Task LogAccessRequest(AccessRequest accessRequest);
     }
 }

--- a/src/ui/ManageApi.cs
+++ b/src/ui/ManageApi.cs
@@ -16,12 +16,37 @@ namespace GovUk.Education.ManageCourses.Ui
             _apiClient = apiClient;
         }
 
-        public async Task<OrganisationCourses> GetCoursesByOrganisation(string ucasCode)
+        public async Task<UserOrganisation> GetOrganisation(string instCode)
         {
             try
             {
-                var courses = await _apiClient.Data_ExportByOrganisationAsync(ucasCode);
+                var courses = await _apiClient.Organisations_GetAsync(instCode);
                 return courses;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Failed to get courses data from " + _apiClient.BaseUrl, ex);
+            }
+        }
+
+        public async Task<InstitutionCourses> GetCoursesByOrganisation(string instCode)
+        {
+            try
+            {
+                var courses = await _apiClient.Courses_GetAllAsync(instCode);
+                return courses;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Failed to get courses data from " + _apiClient.BaseUrl, ex);
+            }
+        }
+        public async Task<Course> GetCourseByUcasCode(string instCode, string ucasCode)
+        {
+            try
+            {
+                var course = await _apiClient.Courses_GetAsync(instCode, ucasCode);
+                return course;
             }
             catch (Exception ex)
             {

--- a/src/ui/ViewModels/CourseListViewModel.cs
+++ b/src/ui/ViewModels/CourseListViewModel.cs
@@ -8,7 +8,9 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
 {
     public class CourseListViewModel : TabbedViewModel
     {
-        public OrganisationCourses Courses { get; set; }
-        public int TotalCount { get; set; }
+        public string InstitutionName { get; set; }
+        public string InstitutionId { get; set; }
+
+        public List<Provider> Providers { get; set; }
     }
 }

--- a/src/ui/ViewModels/Provider.cs
+++ b/src/ui/ViewModels/Provider.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ManageCourses.ApiClient;
+
+namespace GovUk.Education.ManageCourses.Ui.ViewModels
+{
+    public class Provider
+    {
+        public Provider()
+        {
+            Courses = new List<Course>();
+        }
+        public string ProviderName { get; set; }
+        public string ProviderId { get; set; }
+        public List<Course> Courses { get; set; }
+        public int TotalCount { get; set; }
+    }
+}

--- a/src/ui/Views/Organisation/Courses.cshtml
+++ b/src/ui/Views/Organisation/Courses.cshtml
@@ -1,44 +1,44 @@
 ﻿@model CourseListViewModel
 
 @{
-    Layout = "Shared/_TabViewLayout";
-    ViewBag.Title = Model.InstitutionName;
+  Layout = "Shared/_TabViewLayout";
+  ViewBag.Title = Model.InstitutionName;
 }
 
 <section class="govuk-tabs__panel--without-border">
-    <h2 class="govuk-heading-l">Courses</h2>
+  <h2 class="govuk-heading-l">Courses</h2>
 
-    @foreach (var provider in Model.Providers)
+  @foreach (var provider in Model.Providers)
+  {
+    if (!string.IsNullOrWhiteSpace(provider.ProviderId))
     {
-        if (!string.IsNullOrWhiteSpace(provider.ProviderId))
-        {
-            <h3 class="govuk-heading-m">
-                <span class="govuk-caption-m">Accrediting provider</span>
-                @provider.ProviderName
-            </h3>
-        }
-
-        <table class="ucas-info-table govuk-table">
-            <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                    <th class="govuk-table__header ucas-info-table__code-col" scope="col">Code</th>
-                    <th class="govuk-table__header ucas-info-table__subject-col" scope="col">Subject</th>
-                    <th class="govuk-table__header ucas-info-table__type-col" scope="col">Type</th>
-                </tr>
-            </thead>
-            <tbody class="govuk-table__body">
-                @foreach (var course in provider.Courses)
-                {
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">@course.CourseCode</td>
-
-                        <td class="govuk-table__cell">
-                            <a href="@Url.Action("variants", "course", new {instCode = Model.InstitutionId, accreditingProviderId = course.AccreditingProviderId, ucasCode = course.CourseCode})" class="govuk-link">@course.Name</a>
-                        </td>
-                        <td class="govuk-table__cell">@course.GetCourseVariantType()</td>
-                    </tr>
-                }
-            </tbody>
-        </table>
+      <h3 class="govuk-heading-m">
+        <span class="govuk-caption-m">Accrediting provider</span>
+        @provider.ProviderName
+      </h3>
     }
+
+    <table class="ucas-info-table govuk-table">
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header ucas-info-table__code-col" scope="col">Code</th>
+        <th class="govuk-table__header ucas-info-table__subject-col" scope="col">Subject</th>
+        <th class="govuk-table__header ucas-info-table__type-col" scope="col">Type</th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      @foreach (var course in provider.Courses)
+      {
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">@course.CourseCode</td>
+
+          <td class="govuk-table__cell">
+            <a href="@Url.Action("variants", "course", new {instCode = Model.InstitutionId, accreditingProviderId = course.AccreditingProviderId, ucasCode = course.CourseCode})" class="govuk-link">@course.Name</a>
+          </td>
+          <td class="govuk-table__cell">@course.GetCourseVariantType()</td>
+        </tr>
+      }
+      </tbody>
+    </table>
+  }
 </section>

--- a/src/ui/Views/Organisation/Courses.cshtml
+++ b/src/ui/Views/Organisation/Courses.cshtml
@@ -1,46 +1,44 @@
 ﻿@model CourseListViewModel
 
 @{
-  Layout = "Shared/_TabViewLayout";
-  ViewBag.Title = Model.Courses.OrganisationName;
+    Layout = "Shared/_TabViewLayout";
+    ViewBag.Title = Model.InstitutionName;
 }
 
-    <section class="govuk-tabs__panel--without-border">
-      <h2 class="govuk-heading-l">Courses</h2>
+<section class="govuk-tabs__panel--without-border">
+    <h2 class="govuk-heading-l">Courses</h2>
 
-      @foreach (var providerCourse in Model.Courses.ProviderCourses)
-      {
-        if (!string.IsNullOrWhiteSpace(providerCourse.AccreditingProviderId))
+    @foreach (var provider in Model.Providers)
+    {
+        if (!string.IsNullOrWhiteSpace(provider.ProviderId))
         {
-          <h3 class="govuk-heading-m">
-            <span class="govuk-caption-m">Accrediting provider</span>
-            @providerCourse.AccreditingProviderName
-          </h3>
+            <h3 class="govuk-heading-m">
+                <span class="govuk-caption-m">Accrediting provider</span>
+                @provider.ProviderName
+            </h3>
         }
 
         <table class="ucas-info-table govuk-table">
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th class="govuk-table__header ucas-info-table__code-col" scope="col">Code</th>
-              <th class="govuk-table__header ucas-info-table__subject-col" scope="col">Subject</th>
-              <th class="govuk-table__header ucas-info-table__type-col" scope="col">Type</th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            @foreach (var course in providerCourse.CourseDetails)
-            {
-              foreach (var variant in course.Variants)
-              {
+            <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">@variant.UcasCode</td>
-                  <td class="govuk-table__cell">
-                    <a href="@Url.Action("variants", "course", new { instCode = Model.Courses.UcasCode, accreditingProviderId = providerCourse.AccreditingProviderId, ucasCode = variant.UcasCode })" class="govuk-link">@course.CourseTitle</a>
-                  </td>
-                  <td class="govuk-table__cell">@variant.GetCourseVariantType()</td>
+                    <th class="govuk-table__header ucas-info-table__code-col" scope="col">Code</th>
+                    <th class="govuk-table__header ucas-info-table__subject-col" scope="col">Subject</th>
+                    <th class="govuk-table__header ucas-info-table__type-col" scope="col">Type</th>
                 </tr>
-              }
-            }
-          </tbody>
+            </thead>
+            <tbody class="govuk-table__body">
+                @foreach (var course in provider.Courses)
+                {
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">@course.CourseCode</td>
+
+                        <td class="govuk-table__cell">
+                            <a href="@Url.Action("variants", "course", new {instCode = Model.InstitutionId, accreditingProviderId = course.AccreditingProviderId, ucasCode = course.CourseCode})" class="govuk-link">@course.Name</a>
+                        </td>
+                        <td class="govuk-table__cell">@course.GetCourseVariantType()</td>
+                    </tr>
+                }
+            </tbody>
         </table>
-      }
-    </section>
+    }
+</section>

--- a/src/ui/Views/Organisations/Index.cshtml
+++ b/src/ui/Views/Organisations/Index.cshtml
@@ -15,7 +15,7 @@
           <li>
             <h3 class="govuk-heading-m">
               <a href="@Url.Action("Courses", "Organisation", new {ucasCode = organisation.UcasCode})" class="govuk-link">@organisation.OrganisationName</a>
-             @* <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block">@organisation.TotalCourses courses</span>*@
+              <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block">@organisation.TotalCourses courses</span>
             </h3>
           </li>
         }


### PR DESCRIPTION
### Context
A previous PR connected to just organisations new endpoint.
This PR connects to all the new course endpoints
The model/s returned from the new endpoints are completed different and less complex.
The views should remain unchanged.
### Changes proposed in this pull request
The previous PR had the course totals commented out and these have been reinstated.
Tests that were targeting the old model structure were failing and so these were also fixed in this PR 
### Guidance to review
