### PR TITLE
Put back the "Check courses" copy

### DIFF
--- a/src/ui/Views/Organisation/Courses.cshtml
+++ b/src/ui/Views/Organisation/Courses.cshtml
@@ -6,7 +6,19 @@
 }
 
 <section class="govuk-tabs__panel--without-border">
-  <h2 class="govuk-heading-l">Courses</h2>
+  <h2 class="govuk-heading-l">Check your courses</h2>
+  <p>
+    Check that your course information is correct. If there are any problems, you should <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Publish%20teacher%20training%20courses%20problem">contact the Becoming a Teacher team</a> to let us know.
+  </p>
+  <p>
+    To make any changes, for now you’ll still need to use UCAS web-link. Changes on UCAS will normally show here within one working day.
+  </p>
+  <p>
+    Soon you’ll be able to add extra content to tell applicants more about you and your courses. <a href="https://afdebatmanageui.blob.core.windows.net/public-assets/How%20to%20prepare%20the%20rest%20of%20your%20course%20information.pdf">Find out more about this here</a>.
+  </p>
+  <p>
+    In the future, you’ll be able to edit all course information here.
+  </p>
 
   @foreach (var provider in Model.Providers)
   {

--- a/src/ui/Views/Organisation/Courses.cshtml
+++ b/src/ui/Views/Organisation/Courses.cshtml
@@ -7,16 +7,16 @@
 
 <section class="govuk-tabs__panel--without-border">
   <h2 class="govuk-heading-l">Check your courses</h2>
-  <p>
+  <p class="govuk-body">
     Check that your course information is correct. If there are any problems, you should <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Publish%20teacher%20training%20courses%20problem">contact the Becoming a Teacher team</a> to let us know.
   </p>
-  <p>
+  <p class="govuk-body">
     To make any changes, for now you’ll still need to use UCAS web-link. Changes on UCAS will normally show here within one working day.
   </p>
-  <p>
+  <p class="govuk-body">
     Soon you’ll be able to add extra content to tell applicants more about you and your courses. <a href="https://afdebatmanageui.blob.core.windows.net/public-assets/How%20to%20prepare%20the%20rest%20of%20your%20course%20information.pdf">Find out more about this here</a>.
   </p>
-  <p>
+  <p class="govuk-body">
     In the future, you’ll be able to edit all course information here.
   </p>
 


### PR DESCRIPTION
### Context

When we switched from courses to tabs we removed guidance about what to prepare and how to contact us.

Original copy removed in https://github.com/DFE-Digital/manage-courses-ui/pull/82

### Changes proposed in this pull request

Put this copy back. It can be removed once courses can be enriched.

### Guidance to review

I haven't been able to run this locally.
