### PR TITLE
Suppress age range on course info page

### DIFF
--- a/src/ui/Views/Course/Variants.cshtml
+++ b/src/ui/Views/Course/Variants.cshtml
@@ -6,7 +6,7 @@
     var link = "mailto:becomingateacher@digital.education.gov.uk?subject=Problem%20with%20course%20" + Model.Course.ProgrammeCode;
 }
 
-<a href="@Url.Action("Courses", "Organisation", new {ucasCode = Model.Course.UcasCode})" class="govuk-back-link">Back</a>  
+<a href="@Url.Action("Courses", "Organisation", new {ucasCode = Model.Course.UcasCode})" class="govuk-back-link">Back</a>
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
     <h1 class="govuk-heading-xl">
@@ -52,8 +52,10 @@
             <dd>@Model.Course.GetStudyMode()</dd>
         }
         @if (!string.IsNullOrEmpty(@Model.Course.GetAgeRange())) {
-            <dt>Age range:</dt>
-            <dd>@Model.Course.GetAgeRange()</dd>
+            <!--
+              <dt>Age range:</dt>
+              <dd>@Model.Course.GetAgeRange()</dd>
+            -->
         }
         @if (!string.IsNullOrEmpty(@Model.Course.GetQualification())) {
             <dt>Qualification:</dt>

--- a/src/ui/Views/Course/Variants.cshtml
+++ b/src/ui/Views/Course/Variants.cshtml
@@ -51,12 +51,6 @@
             <dt>Mode of study:</dt>
             <dd>@Model.Course.GetStudyMode()</dd>
         }
-        @if (!string.IsNullOrEmpty(@Model.Course.GetAgeRange())) {
-            <!--
-              <dt>Age range:</dt>
-              <dd>@Model.Course.GetAgeRange()</dd>
-            -->
-        }
         @if (!string.IsNullOrEmpty(@Model.Course.GetQualification())) {
             <dt>Qualification:</dt>
             <dd>@Model.Course.GetQualification()</dd>


### PR DESCRIPTION
### Context

UCAS has 3 possible age ranges:
- Primary (3-11/12)
- Middle years (7 - 14 years)
- Secondary (11+)

This age range doesn't fit all courses, but it's what's set in UCAS. When we show this to training providers they rightly point out that the age range is wrong and request changes.

### Changes proposed in this pull request

We don't use this data, it doesn't matter if it's correct. We can hide it for now to avoid confusion about age range and reduce support requests.

### Guidance to review

Check rendering, I can't run locally.
