### PR TITLE
Better error handling in HomeController

### DIFF
--- a/ManageCoursesUi.Tests/Controllers/HomeControllerTests.cs
+++ b/ManageCoursesUi.Tests/Controllers/HomeControllerTests.cs
@@ -1,0 +1,51 @@
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ManageCourses.ApiClient;
+using GovUk.Education.ManageCourses.Ui;
+using GovUk.Education.ManageCourses.Ui.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+
+namespace ManageCoursesUi.Tests
+{
+    [TestFixture]
+    public class HomeControllerTests
+    {
+        private HomeController sut;
+        private Mock<IManageApi> mockApi;
+
+        [SetUp]
+        public void SetUp() 
+        {
+            mockApi = new Mock<IManageApi>();
+            sut = new HomeController(mockApi.Object); 
+        } 
+
+        [Test]
+        public void Index_IfNoOrgs_Returns401()
+        {
+            mockApi.Setup(x => x.GetOrganisations())
+                .Returns(Task.FromResult((IEnumerable<UserOrganisation>) new List<UserOrganisation>()));
+            
+            var res = sut.Index().Result;
+
+            Assert.IsTrue(res is StatusCodeResult);
+            Assert.AreEqual(401, (res as StatusCodeResult).StatusCode);
+        }
+        
+        [Test]
+        public void Index_IfApiThrows401_Returns401()
+        {
+            mockApi.Setup(x => x.GetOrganisations())
+                .ThrowsAsync(new SwaggerException("uh-oh...", 401, "", new Dictionary<string, IEnumerable<string>>(), new Exception("inner")));
+            
+            var res = sut.Index().Result;
+
+            Assert.IsTrue(res is StatusCodeResult);
+            Assert.AreEqual(401, (res as StatusCodeResult).StatusCode);
+        }
+    }
+}

--- a/src/ui/Controllers/HomeController.cs
+++ b/src/ui/Controllers/HomeController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using GovUk.Education.ManageCourses.ApiClient;
 using GovUk.Education.ManageCourses.Ui.ViewModels;
 using GovUk.Education.ManageCourses.Ui;
+using System.Collections.Generic;
 
 namespace GovUk.Education.ManageCourses.Ui.Controllers
 {
@@ -22,8 +23,24 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         // GET: Home
         [Authorize]
         public async Task<ActionResult> Index()
-        {
-            var orgs = await _manageApi.GetOrganisations();
+        {            
+            IEnumerable<UserOrganisation> orgs;
+            
+            try
+            {
+                orgs = await _manageApi.GetOrganisations();
+            }
+            catch (SwaggerException e)
+            {
+                if (e.StatusCode == 401)
+                {
+                    return StatusCode(401);
+                }
+                else
+                {
+                    throw;
+                }
+            }
 
             var userOrganisations = orgs.ToList();
             if (userOrganisations.Count() == 1)
@@ -36,7 +53,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                 return this.RedirectToAction("Index", "Organisations");
             }
 
-            throw new Exception("No organisations returned from API for this user");
+            return StatusCode(401);
         }
     }
 }


### PR DESCRIPTION
### Context

Exceptions clog the log. https://trello.com/c/N4YAiQTG/78-exceptions-get-thrown-by-managecourses-ui-homecontroller-during-normal-operation

### Changes proposed in this pull request

Return a status code (401) when no organisations are found, rather than throwing an exception

### Guidance to review

n/a
