### PR TITLE
Feature flag for About Orgs

### DIFF
--- a/src/ui/IFeatureFlags.cs
+++ b/src/ui/IFeatureFlags.cs
@@ -12,7 +12,7 @@ namespace GovUk.Education.ManageCourses.Ui
     {
         private readonly IConfigurationSection _config;
 
-        private const string FEATURE_ORG_ENRICHMENT = "FEATURE_ORG_ENRICHEMENT";
+        private const string FEATURE_ORG_ENRICHMENT = "FEATURE_ORG_ENRICHMENT";
 
         public FeatureFlags(IConfigurationSection config)
         {

--- a/src/ui/IFeatureFlags.cs
+++ b/src/ui/IFeatureFlags.cs
@@ -1,0 +1,26 @@
+
+using Microsoft.Extensions.Configuration;
+
+namespace GovUk.Education.ManageCourses.Ui
+{
+    public interface IFeatureFlags 
+    {
+        bool ShowOrgEnrichment { get; }
+    }
+
+    public class FeatureFlags : IFeatureFlags
+    {
+        private readonly IConfigurationSection _config;
+
+        private const string FEATURE_ORG_ENRICHMENT = "FEATURE_ORG_ENRICHEMENT";
+
+        public FeatureFlags(IConfigurationSection config)
+        {
+            _config = config;
+        } 
+
+        public bool ShowOrgEnrichment => ShouldShow(FEATURE_ORG_ENRICHMENT);
+
+        private bool ShouldShow(string key) => _config.GetValue(key, false);
+    }
+}

--- a/src/ui/Startup.cs
+++ b/src/ui/Startup.cs
@@ -193,6 +193,7 @@ namespace GovUk.Education.ManageCourses.Ui
                 };
             });
 
+            services.AddSingleton<IFeatureFlags>(x => new FeatureFlags(Configuration.GetSection("features")));
             services.AddSingleton<IManageCoursesApiClientConfiguration, ManageCoursesApiClientConfiguration>();
             services.AddScoped(provider => AnalyticsPolicy.FromEnv());
             services.AddScoped<AnalyticsAttribute>();

--- a/src/ui/ViewModels/TabViewModel.cs
+++ b/src/ui/ViewModels/TabViewModel.cs
@@ -12,5 +12,6 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         public string OrganisationName { get; set; }
         public string CurrentTab { get; set; }
         public string UcasCode { get; set; }
+        public bool ShowAboutTab { get; set; }
     }
 }

--- a/src/ui/Views/Organisation/Shared/_TabViewLayout.cshtml
+++ b/src/ui/Views/Organisation/Shared/_TabViewLayout.cshtml
@@ -37,11 +37,13 @@
                 Courses
             </a>
         </li>
-        <li class="govuk-tabs__list-item">
-            <a class="govuk-tabs__tab" href="@Url.Action("About", "Organisation")" aria-selected="@isAboutTab.ToString().ToLower()">
-                About your organisation
-            </a>
-        </li>
+        @if(viewModel.ShowAboutTab) {
+            <li class="govuk-tabs__list-item">
+                <a class="govuk-tabs__tab" href="@Url.Action("About", "Organisation")" aria-selected="@isAboutTab.ToString().ToLower()">
+                    About your organisation
+                </a>
+            </li>
+        }
         <li class="govuk-tabs__list-item">
             <a class="govuk-tabs__tab" href="@Url.Action("RequestAccess", "Organisation", modelValues)" aria-selected="@isRequestAccessTab.ToString().ToLower()">
                 Request access for someone else


### PR DESCRIPTION
### Context

We want to release Manage courses today but without the enrichment UI

### Changes proposed in this pull request

Introduce a FeatureFlags service

When the `ShowOrgEnrichment` flag isn't set to true, hide the about tab and redirect calls to the about endpoint to the courses tab

### Guidance to review

Have a look at the new test as an entry point