### PR TITLE
Accredited provider, not accrediting provider

### DIFF
--- a/src/ui/Views/Course/Variants.cshtml
+++ b/src/ui/Views/Course/Variants.cshtml
@@ -34,7 +34,7 @@
               <dd>@Model.Course.ProgrammeCode</dd>
             }
             @if (!string.IsNullOrEmpty(@Model.Course.Accrediting)) {
-              <dt>Accrediting provider:</dt>
+              <dt>Accredited provider:</dt>
               <dd>@Model.Course.Accrediting</dd>
             }
             @if (!string.IsNullOrEmpty(@Model.Course.GetRoute())) {

--- a/src/ui/Views/Organisation/About.cshtml
+++ b/src/ui/Views/Organisation/About.cshtml
@@ -35,8 +35,8 @@
         </div>
 
         @if(Model.AboutTrainingProviders.Any()) {
-          <h2 class="govuk-heading-l">About your accrediting provider</h2>
-          <p class="govuk-body">Describe advantages and special features of your accrediting provider. You must be specific and factual with any claims you make, and support them with evidence.</p>
+          <h2 class="govuk-heading-l">About your accredited provider</h2>
+          <p class="govuk-body">Describe any advantages and special features of your accredited provider. You must be specific and factual with any claims you make, and support them with evidence.</p>
 
           @for (int i = 0; i < Model.AboutTrainingProviders.Count; i++) {
               var aboutTrainingProviderKey = "AboutTrainingProviders_"+i+"__Description";

--- a/src/ui/Views/Organisation/Courses.cshtml
+++ b/src/ui/Views/Organisation/Courses.cshtml
@@ -29,7 +29,7 @@
     if (!string.IsNullOrWhiteSpace(provider.ProviderId))
     {
       <h3 class="govuk-heading-m">
-        <span class="govuk-caption-m">Accrediting provider</span>
+        <span class="govuk-caption-m">Accredited provider</span>
         @provider.ProviderName
       </h3>
     }


### PR DESCRIPTION
### Context

In our Search fact-check for private beta it was highlighted that providers are "accredited" not "accrediting". eg See https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice

UCAS and users use "Accrediting", but we shouldn't propagate this difference.

### Changes proposed in this pull request

Accredited provider, not accrediting provider

### Guidance to review

We might want to update the code variable names and so on at some point.
