### PR TITLE
Remove about org feature flag

### DIFF
--- a/ManageCoursesUi.Tests/Controllers/OrganisationControllerTests.cs
+++ b/ManageCoursesUi.Tests/Controllers/OrganisationControllerTests.cs
@@ -55,7 +55,7 @@ namespace ManageCoursesUi.Tests
 
             apiMock.Setup(x => x.GetOrganisations()).ReturnsAsync(orgs);
 
-            var controller = new OrganisationController(apiMock.Object, GetFeatureFlagMock().Object);
+            var controller = new OrganisationController(apiMock.Object);
 
             var result = await controller.Courses(ucasCode);
 
@@ -95,7 +95,7 @@ namespace ManageCoursesUi.Tests
             apiMock.Setup(x => x.GetOrganisations())
                 .ReturnsAsync(orgs);
 
-            var controller = new OrganisationController(apiMock.Object, GetFeatureFlagMock().Object);
+            var controller = new OrganisationController(apiMock.Object);
 
             var result = await controller.RequestAccess(ucasCode);
 
@@ -132,7 +132,7 @@ namespace ManageCoursesUi.Tests
             apiMock.Setup(x => x.GetOrganisations())
                 .ReturnsAsync(orgs);
 
-            var controller = new OrganisationController(apiMock.Object, GetFeatureFlagMock().Object);
+            var controller = new OrganisationController(apiMock.Object);
             controller.ModelState.AddModelError("you", "failed");
             var result = await controller.RequestAccessPost(ucasCode, new RequestAccessViewModel());
 
@@ -159,7 +159,7 @@ namespace ManageCoursesUi.Tests
 
             var tempDataMock = new Mock<ITempDataDictionary>();
 
-            var controller = new OrganisationController(apiMock.Object, GetFeatureFlagMock().Object);
+            var controller = new OrganisationController(apiMock.Object);
             controller.TempData = tempDataMock.Object;
 
             var result = await controller.RequestAccessPost(ucasCode, viewModel);
@@ -237,7 +237,7 @@ namespace ManageCoursesUi.Tests
             apiMock.Setup(x => x.GetEnrichmentOrganisation(ucasCode))
                 .ReturnsAsync(ucasInstitutionEnrichmentGetModel);
 
-            var controller = new OrganisationController(apiMock.Object, GetFeatureFlagMock().Object);
+            var controller = new OrganisationController(apiMock.Object);
 
             var result = await controller.About(ucasCode);
 
@@ -258,23 +258,6 @@ namespace ManageCoursesUi.Tests
             Assert.IsFalse(tabViewModel.MultipleOrganisations);
             Assert.AreEqual(now, organisationViewModel.LastPublishedTimestampUtc);
             Assert.AreEqual(EnumStatus.Published, organisationViewModel.Status);
-        }
-
-        [Test]
-        public void EnrichmentFeatureFlag()
-        {
-            // ARRANGE
-             var flagMock = new Mock<IFeatureFlags>();
-            flagMock.SetupGet(x => x.ShowOrgEnrichment).Returns(false);
-            var controller = new OrganisationController(new Mock<IManageApi>().Object, flagMock.Object);
-             // ACT
-
-            var res = controller.About("123").Result;
-             // ASSERT
-             Assert.That(res is RedirectToActionResult, "About page should redirect");
-            Assert.AreEqual(false, (res as RedirectToActionResult).Permanent, "Redirect shouldn't be permanent");
-            Assert.AreEqual("Courses", (res as RedirectToActionResult).ActionName, "Redirect should go to courses action");
-            Assert.AreEqual("123", (res as RedirectToActionResult).RouteValues["ucasCode"], "Redirect should use same UCAS Code");
         }
 
         [Test]
@@ -321,7 +304,7 @@ namespace ManageCoursesUi.Tests
                 It.IsAny<string>(),
                 It.IsAny<Object>()));
 
-            var controller = new OrganisationController(apiMock.Object, GetFeatureFlagMock().Object);
+            var controller = new OrganisationController(apiMock.Object);
 
             controller.ObjectValidator = objectValidator.Object;
 
@@ -386,7 +369,7 @@ namespace ManageCoursesUi.Tests
                 It.IsAny<string>(),
                 It.IsAny<Object>()));
 
-            var controller = new OrganisationController(apiMock.Object, GetFeatureFlagMock().Object);
+            var controller = new OrganisationController(apiMock.Object);
             controller.ObjectValidator = objectValidator.Object;
 
             var result = await controller.AboutPost(ucasCode, viewModel);
@@ -447,7 +430,7 @@ namespace ManageCoursesUi.Tests
 
             apiMock.Setup(x => x.PublishEnrichmentOrganisation(ucasCode))
                 .ReturnsAsync(true);
-            var controller = new OrganisationController(apiMock.Object, GetFeatureFlagMock().Object);
+            var controller = new OrganisationController(apiMock.Object);
             controller.ObjectValidator = objectValidator.Object;
 
             var result = await controller.AboutPost(ucasCode, viewModel);
@@ -528,7 +511,7 @@ namespace ManageCoursesUi.Tests
 
             apiMock.Setup(x => x.PublishEnrichmentOrganisation(ucasCode))
                 .ReturnsAsync(true);
-            var controller = new OrganisationControllerMockedValidation(apiMock.Object, GetFeatureFlagMock().Object);
+            var controller = new OrganisationControllerMockedValidation(apiMock.Object);
 
             var result = await controller.AboutPost(ucasCode, viewModel);
 
@@ -605,7 +588,7 @@ namespace ManageCoursesUi.Tests
                 It.IsAny<string>(),
                 It.IsAny<Object>()));
 
-            var controller = new OrganisationController(apiMock.Object, GetFeatureFlagMock().Object);
+            var controller = new OrganisationController(apiMock.Object);
 
             controller.ObjectValidator = objectValidator.Object;
 
@@ -628,13 +611,6 @@ namespace ManageCoursesUi.Tests
             Assert.AreEqual(exceed100Words, organisationViewModel.AboutTrainingProviders.First(x => x.InstitutionCode == ucasCode + 1).Description);
             Assert.AreEqual(institutionName, organisationViewModel.AboutTrainingProviders.First(x => x.InstitutionCode == ucasCode + 1).InstitutionName);
 
-        }
-
-        private Mock<IFeatureFlags> GetFeatureFlagMock()
-        {
-            var mock = new Mock<IFeatureFlags>();
-            mock.SetupGet(x => x.ShowOrgEnrichment).Returns(true);
-            return mock;
         }
     }
 }

--- a/ManageCoursesUi.Tests/Mocks/OrganisationControllerMockedValidation.cs
+++ b/ManageCoursesUi.Tests/Mocks/OrganisationControllerMockedValidation.cs
@@ -10,7 +10,7 @@ namespace ManageCoursesUi.Tests.Mocks
 {
     public class OrganisationControllerMockedValidation : OrganisationController
     {
-        public OrganisationControllerMockedValidation(IManageApi manageApi, IFeatureFlags featureFlags) : base(manageApi, featureFlags) { }
+        public OrganisationControllerMockedValidation(IManageApi manageApi) : base(manageApi) { }
         public override bool TryValidateModel(object model)
         {
             this.ModelState.AddModelError("you", "failed");

--- a/src/ui/Controllers/OrganisationController.cs
+++ b/src/ui/Controllers/OrganisationController.cs
@@ -19,12 +19,10 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
     public class OrganisationController : CommonAttributesControllerBase
     {
         private readonly IManageApi _manageApi;
-        private readonly IFeatureFlags _featureFlags;
 
-        public OrganisationController(IManageApi manageApi, IFeatureFlags featureFlags)
+        public OrganisationController(IManageApi manageApi)
         {
             _manageApi = manageApi;
-            _featureFlags = featureFlags;
         }
 
         [Route("{ucasCode}/courses")]
@@ -49,12 +47,6 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         [Route("{ucasCode}/about")]
         public async Task<IActionResult> About(string ucasCode)
         {
-
-            if (!_featureFlags.ShowOrgEnrichment)
-            {
-                return RedirectToAction("Courses", new { ucasCode = ucasCode });
-            }
-
             var ucasInstitutionEnrichmentGetModel = await _manageApi.GetEnrichmentOrganisation(ucasCode);
 
             var tabViewModel = await GetTabViewModelAsync(ucasCode, "about");
@@ -297,8 +289,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                 CurrentTab = currentTab,
                 MultipleOrganisations = orgs.Count() > 1,
                 OrganisationName = organisationName,
-                UcasCode = ucasCode,
-                ShowAboutTab = _featureFlags.ShowOrgEnrichment
+                UcasCode = ucasCode
             };
 
             return result;

--- a/src/ui/IFeatureFlags.cs
+++ b/src/ui/IFeatureFlags.cs
@@ -1,11 +1,9 @@
-
 using Microsoft.Extensions.Configuration;
 
 namespace GovUk.Education.ManageCourses.Ui
 {
-    public interface IFeatureFlags 
+    public interface IFeatureFlags
     {
-        bool ShowOrgEnrichment { get; }
         bool ShowCoursePreview { get; }
         bool ShowCoursePublish { get; }
     }
@@ -14,16 +12,13 @@ namespace GovUk.Education.ManageCourses.Ui
     {
         private readonly IConfigurationSection _config;
 
-        private const string FEATURE_ORG_ENRICHMENT = "FEATURE_ORG_ENRICHMENT";
         private const string FEATURE_COURSE_PREVIEW = "FEATURE_COURSE_PREVIEW";
         private const string FEATURE_COURSE_PUBLISH = "FEATURE_COURSE_PUBLISH";
 
         public FeatureFlags(IConfigurationSection config)
         {
             _config = config;
-        } 
-
-        public bool ShowOrgEnrichment => ShouldShow(FEATURE_ORG_ENRICHMENT);
+        }
 
         public bool ShowCoursePreview => ShouldShow(FEATURE_COURSE_PREVIEW);
 

--- a/src/ui/Views/Organisation/Shared/_TabViewLayout.cshtml
+++ b/src/ui/Views/Organisation/Shared/_TabViewLayout.cshtml
@@ -37,13 +37,11 @@
                 Courses
             </a>
         </li>
-        @if(viewModel.ShowAboutTab) {
-            <li class="govuk-tabs__list-item">
-                <a class="govuk-tabs__tab" href="@Url.Action("About", "Organisation")" aria-selected="@isAboutTab.ToString().ToLower()">
-                    About your organisation
-                </a>
-            </li>
-        }
+        <li class="govuk-tabs__list-item">
+            <a class="govuk-tabs__tab" href="@Url.Action("About", "Organisation")" aria-selected="@isAboutTab.ToString().ToLower()">
+                About your organisation
+            </a>
+        </li>
         <li class="govuk-tabs__list-item">
             <a class="govuk-tabs__tab" href="@Url.Action("RequestAccess", "Organisation", modelValues)" aria-selected="@isRequestAccessTab.ToString().ToLower()">
                 Request access for someone else


### PR DESCRIPTION
### Context
About your org is in production and working so the feature is an unnecessary overhead 

### Changes proposed in this pull request
Remove feature flag from about org

### Guidance to review
Don't set any feature flags and try to access the about org tab(page).

Ignore whitespace https://github.com/DFE-Digital/manage-courses-ui/pull/120/files?utf8=%E2%9C%93&diff=unified&w=1
