### PR TITLE
protect live view with feature flag

### DIFF
--- a/ManageCoursesUi.Tests/CourseControllerTests.cs
+++ b/ManageCoursesUi.Tests/CourseControllerTests.cs
@@ -525,11 +525,11 @@ namespace ManageCoursesUi.Tests
         
         private class MockFeatureFlags : IFeatureFlags
         {
-            public bool ShowOrgEnrichment => true;
-
             public bool ShowCoursePreview => true;
 
             public bool ShowCoursePublish => true;
+            
+            public bool ShowCourseLiveView => true;
         }
     }
 }

--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -277,7 +277,8 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                 RouteData = routeData,
                 LiveSearchUrl = searchAndCompareUrlService.GetCoursePageUri(org.UcasCode, courseVariant.ProgrammeCode),
                 AllowPreview = featureFlags.ShowCoursePreview,
-                AllowPublish = featureFlags.ShowCoursePublish
+                AllowPublish = featureFlags.ShowCoursePublish,
+                AllowLiveView = featureFlags.ShowCourseLiveView
             };
             return viewModel;
         }

--- a/src/ui/FeatureFlags.cs
+++ b/src/ui/FeatureFlags.cs
@@ -7,7 +7,6 @@ namespace GovUk.Education.ManageCourses.Ui
     {
         private readonly IConfigurationSection _config;
 
-        private const string FEATURE_ORG_ENRICHMENT = "FEATURE_ORG_ENRICHMENT";
         private const string FEATURE_COURSE_PREVIEW = "FEATURE_COURSE_PREVIEW";
         private const string FEATURE_COURSE_PUBLISH = "FEATURE_COURSE_PUBLISH";
         private const string FEATURE_COURSE_LIVEVIEW = "FEATURE_COURSE_LIVEVIEW";
@@ -16,8 +15,6 @@ namespace GovUk.Education.ManageCourses.Ui
         {
             _config = config;
         } 
-
-        public bool ShowOrgEnrichment => ShouldShow(FEATURE_ORG_ENRICHMENT);
 
         public bool ShowCoursePreview => ShouldShow(FEATURE_COURSE_PREVIEW);
 

--- a/src/ui/FeatureFlags.cs
+++ b/src/ui/FeatureFlags.cs
@@ -1,0 +1,30 @@
+
+using Microsoft.Extensions.Configuration;
+
+namespace GovUk.Education.ManageCourses.Ui
+{
+    public class FeatureFlags : IFeatureFlags
+    {
+        private readonly IConfigurationSection _config;
+
+        private const string FEATURE_ORG_ENRICHMENT = "FEATURE_ORG_ENRICHMENT";
+        private const string FEATURE_COURSE_PREVIEW = "FEATURE_COURSE_PREVIEW";
+        private const string FEATURE_COURSE_PUBLISH = "FEATURE_COURSE_PUBLISH";
+        private const string FEATURE_COURSE_LIVEVIEW = "FEATURE_COURSE_LIVEVIEW";
+
+        public FeatureFlags(IConfigurationSection config)
+        {
+            _config = config;
+        } 
+
+        public bool ShowOrgEnrichment => ShouldShow(FEATURE_ORG_ENRICHMENT);
+
+        public bool ShowCoursePreview => ShouldShow(FEATURE_COURSE_PREVIEW);
+
+        public bool ShowCoursePublish => ShouldShow(FEATURE_COURSE_PUBLISH);
+
+        public bool ShowCourseLiveView => ShouldShow(FEATURE_COURSE_LIVEVIEW);
+
+        private bool ShouldShow(string key) => _config.GetValue(key, false);
+    }
+}

--- a/src/ui/IFeatureFlags.cs
+++ b/src/ui/IFeatureFlags.cs
@@ -1,29 +1,9 @@
-using Microsoft.Extensions.Configuration;
-
 namespace GovUk.Education.ManageCourses.Ui
 {
     public interface IFeatureFlags
     {
         bool ShowCoursePreview { get; }
         bool ShowCoursePublish { get; }
-    }
-
-    public class FeatureFlags : IFeatureFlags
-    {
-        private readonly IConfigurationSection _config;
-
-        private const string FEATURE_COURSE_PREVIEW = "FEATURE_COURSE_PREVIEW";
-        private const string FEATURE_COURSE_PUBLISH = "FEATURE_COURSE_PUBLISH";
-
-        public FeatureFlags(IConfigurationSection config)
-        {
-            _config = config;
-        }
-
-        public bool ShowCoursePreview => ShouldShow(FEATURE_COURSE_PREVIEW);
-
-        public bool ShowCoursePublish => ShouldShow(FEATURE_COURSE_PUBLISH);
-
-        private bool ShouldShow(string key) => _config.GetValue(key, false);
+        bool ShowCourseLiveView { get; }
     }
 }

--- a/src/ui/ViewModels/FromUcasViewModel.cs
+++ b/src/ui/ViewModels/FromUcasViewModel.cs
@@ -7,6 +7,7 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
     {
         public bool AllowPreview { get; set; }
         public bool AllowPublish { get;  set; }
+        public bool AllowLiveView { get;  set; }
         public string OrganisationName { get; set; }
         public string OrganisationId { get; set; }
         public bool MultipleOrganisations { get; set; }

--- a/src/ui/Views/Course/Variants.cshtml
+++ b/src/ui/Views/Course/Variants.cshtml
@@ -195,9 +195,12 @@
             }
         }
 
-        <h4 class="govuk-heading-m">View on website</h4>
-        <p class="govuk-body">See how this course currently looks to applicants:</p>
-        <p class="govuk-body"><a href="@Model.LiveSearchUrl">View on website</a></p>
+        @if(Model.AllowLiveView)
+        {
+          <h4 class="govuk-heading-m">View on website</h4>
+          <p class="govuk-body">See how this course currently looks to applicants:</p>
+          <p class="govuk-body"><a href="@Model.LiveSearchUrl">View on website</a></p>
+        }
       </aside>
     </div>
   </div>


### PR DESCRIPTION
### Context

The "View your current course on Search and compare" bit shouldn't show until we can deploy data to search and compare.

### Changes proposed in this pull request

Introduce another feature flag

### Guidance to review

n/a