### PR TITLE
fix status message clash 

### DIFF
--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -50,16 +50,6 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
 
             var viewModel = LoadViewModel(org, course, multipleOrganisations, ucasCourseEnrichmentGetModel, routeData);
 
-            if (viewModel.Course.Status.Equals("Running", StringComparison.InvariantCultureIgnoreCase))
-                return View(viewModel);
-             //setup the alert message box for non running courses
-            this.TempData.Add("MessageType", "notice");
-            this.TempData.Add("MessageTitle",
-                viewModel.Course.Status.Equals("Not running", StringComparison.InvariantCultureIgnoreCase)
-                    ? "This course is not running."
-                    : "This course is new and not yet running.");
-            this.TempData.Add("MessageBodyHtml", "It won’t appear online. To publish it you need to set the status of at least one training location to “running” in <a href='https://update.ucas.co.uk/cgi-bin/hsrun.hse/NetUpdate/netupdate2/netupdate2.hjx;start=netupdate2.HsLoginPage.run'>UCAS web-link</a>.");
-
             return View("Variants", viewModel);
         }
 

--- a/src/ui/Helpers/ViewModelHelpers.cs
+++ b/src/ui/Helpers/ViewModelHelpers.cs
@@ -21,15 +21,15 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
         public static string GetCourseStatus(this Course course)
         {
             var result = "";
-            if (course.Schools.Any(s => s.Status.ToLower() == "r"))
+            if (course.Schools.Any(s => String.Equals(s.Status, "r", StringComparison.InvariantCultureIgnoreCase)))
             {
                 result = "Running";
             }
-            else if (course.Schools.Any(s => s.Status.ToLower() == "n"))
+            else if (course.Schools.Any(s => String.Equals(s.Status, "n", StringComparison.InvariantCultureIgnoreCase)))
             {
                 result = "New – not yet running";
             }
-            else if (course.Schools.Any(s => s.Status.ToLower() == "d") || course.Schools.Any(s => s.Status.ToLower() == "s"))
+            else if (course.Schools.Any(s => String.Equals(s.Status, "d", StringComparison.InvariantCultureIgnoreCase)) || course.Schools.Any(s => String.Equals(s.Status, "s", StringComparison.InvariantCultureIgnoreCase)))
             {
                 result = "Not running";
             }

--- a/src/ui/ViewModels/FromUcasViewModel.cs
+++ b/src/ui/ViewModels/FromUcasViewModel.cs
@@ -35,9 +35,16 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         public string StudyMode { get; set; }
         public string Regions { get; set; }
         public string Status { get; set; }
+
+        public CourseVariantStatus StatusAsEnum => 
+                string.Equals("running", Status ?? "", StringComparison.InvariantCultureIgnoreCase) ? CourseVariantStatus.Running
+              : string.Equals("not running", Status ?? "", StringComparison.InvariantCultureIgnoreCase) ? CourseVariantStatus.NotRunning
+              : CourseVariantStatus.New;            
+        
         public IEnumerable<SchoolViewModel> Schools { get; set; }
 
     }
+    
 
     public class SchoolViewModel
     {
@@ -60,4 +67,10 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
             return DateTime.TryParse(dateToFormat, out var date) ? date.ToString("dd MMM yyyy") : dateToFormat;
         }
     }
+    public enum CourseVariantStatus
+    {
+        Running,
+        NotRunning,
+        New
+    };
 }

--- a/src/ui/Views/Course/Variants.cshtml
+++ b/src/ui/Views/Course/Variants.cshtml
@@ -20,6 +20,27 @@
 
   @Html.Partial("~/Views/Shared/_Alerts.cshtml")
 
+  @if(Model.Course.StatusAsEnum != CourseVariantStatus.Running)
+  {
+    <div class="govuk-notice-summary" role="alert">
+      <h3 class="govuk-notice-summary__title">
+        @if(Model.Course.StatusAsEnum == CourseVariantStatus.New)
+        {
+          <text>This course is new and not yet running.</text>
+        }
+        else 
+        {
+          <text>This course is not running.</text>
+        }
+      </h3>
+      <div class="govuk-notice-summary__body">
+        <p clas="govuk-body">
+          It won&#8217;t appear online. To publish it you need to set the status of at least one training location to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/cgi-bin/hsrun.hse/NetUpdate/netupdate2/netupdate2.hjx;start=netupdate2.HsLoginPage.run'>UCAS web-link</a>.
+        </p>
+      </div>
+    </div>
+  }
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="course-parts">

--- a/src/ui/Views/Course/Variants.cshtml
+++ b/src/ui/Views/Course/Variants.cshtml
@@ -10,6 +10,7 @@
 
 <a href="@Url.Action("Courses", "Organisation", new {ucasCode = Model.Course.UcasCode})" class="govuk-back-link">Back</a>
 
+@Html.Partial("~/Views/Shared/_Alerts.cshtml")
 @Html.Partial("Shared/ErrorSummary.cshtml")
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
@@ -17,8 +18,6 @@
     <span class="govuk-caption-xl">@Model.Course.Type</span>
     @Model.Course.Name (@Model.Course.ProgrammeCode)
   </h1>
-
-  @Html.Partial("~/Views/Shared/_Alerts.cshtml")
 
   @if(Model.Course.StatusAsEnum != CourseVariantStatus.Running)
   {


### PR DESCRIPTION
### Context

Saving enrichment data on a "new" or "not running" course fails to render a success message because the success message TempData is hogged by information about this being a new or "not running" course. The clash throws an unhandled duplicate key exception.

### Changes proposed in this pull request

fix the fact that new courses were abusing status messages thus causing clashes when there were real notifications; also make status comparsions more defensive

### Guidance to review

n/a