### PR TITLE
fix javascript back link

### DIFF
--- a/src/ui/Assets/Javascript/back-link.js
+++ b/src/ui/Assets/Javascript/back-link.js
@@ -1,0 +1,26 @@
+function BackLink ($module) {
+  this.$module = $module
+}
+
+BackLink.prototype.init = function () {
+  var $module = this.$module
+
+  if (!$module) {
+    return
+  }
+
+  window.addEventListener('load', function () {
+    var $isInternalReferrer = document.referrer.indexOf(location.protocol + "//" + location.host) === 0;
+
+    if ($isInternalReferrer) {
+      var $link = document.createElement("a");
+      $link.setAttribute("href", "javascript:history.back()");
+      $link.setAttribute("class", "govuk-back-link")
+      $link.textContent = "Back to search results";
+
+      $module.appendChild($link);
+    }
+  })
+}
+
+export default BackLink

--- a/src/ui/Assets/app.js
+++ b/src/ui/Assets/app.js
@@ -1,5 +1,6 @@
 import { initAll } from 'govuk-frontend';
 import CookieMessage from './Javascript/cookie-message';
+import BackLink from './Javascript/back-link';
 import CharacterCount from './Javascript/character-count';
 import serialize from 'form-serialize';
 import './Styles/site.scss';
@@ -8,6 +9,9 @@ initAll();
 
 var $cookieMessage = document.querySelector('[data-module="cookie-message"]');
 new CookieMessage($cookieMessage).init();
+
+var $backLink = document.querySelector('[data-module="back-link"]');
+new BackLink($backLink).init();
 
 var $textareas = document.querySelectorAll('[data-module="character-count"]')
 for (var i = $textareas.length - 1; i >= 0; i--) {


### PR DESCRIPTION
### Context

JS-based back links are in the HTML markup but the corresponding javascript was missing

### Changes proposed in this pull request

Add Javascript from search-and-compare-ui that enable the back links

### Guidance to review

these are used to make the back links on the "preview" screen work