### PR TITLE
dont create a new draft for an empty save; refactor viewmodel-merge

### DIFF
--- a/src/ui/ManageApi.cs
+++ b/src/ui/ManageApi.cs
@@ -67,8 +67,6 @@ namespace GovUk.Education.ManageCourses.Ui
         {
             var result = await _apiClient.Enrichment_GetInstitutionAsync(ucasCode);
 
-            result = result ?? new UcasInstitutionEnrichmentGetModel { EnrichmentModel = new InstitutionEnrichmentModel() { AccreditingProviderEnrichments = new ObservableCollection<AccreditingProviderEnrichment>() } };
-
             return result;
         }
 

--- a/src/ui/ViewModels/AboutCourseEnrichmentViewModel.cs
+++ b/src/ui/ViewModels/AboutCourseEnrichmentViewModel.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ManageCourses.ApiClient;
+
 namespace GovUk.Education.ManageCourses.Ui.ViewModels
 {
 
@@ -18,5 +20,18 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         public CourseRouteDataViewModel RouteData { get; set; }
 
         public CourseInfoViewModel CourseInfo { get; set; }
+
+        public bool IsEmpty() =>
+            string.IsNullOrEmpty(AboutCourse) && 
+            string.IsNullOrEmpty(InterviewProcess) && 
+            string.IsNullOrEmpty(HowSchoolPlacementsWork);
+
+        public void MapInto(ref CourseEnrichmentModel enrichmentModel)
+        {
+            enrichmentModel.AboutCourse = AboutCourse;
+            enrichmentModel.InterviewProcess = InterviewProcess;
+            enrichmentModel.HowSchoolPlacementsWork = HowSchoolPlacementsWork;            
+        }
+             
     }
 }

--- a/src/ui/ViewModels/CourseFeesEnrichmentViewModel.cs
+++ b/src/ui/ViewModels/CourseFeesEnrichmentViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ManageCourses.ApiClient;
 using GovUk.Education.ManageCourses.Ui.ViewModels.Enums;
 
 namespace GovUk.Education.ManageCourses.Ui.ViewModels
@@ -19,5 +20,23 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         public CourseRouteDataViewModel RouteData { get; set; }
 
         public CourseInfoViewModel CourseInfo { get; set; }
+
+        public bool IsEmpty() => 
+            !CourseLength.HasValue && 
+            !FeeUkEu.HasValue && 
+            !FeeInternational.HasValue && 
+            string.IsNullOrEmpty(FeeDetails) &&
+            string.IsNullOrEmpty(FinancialSupport);
+
+        public void MapInto(ref CourseEnrichmentModel enrichmentModel)
+        {
+            var courseLength = CourseLength.HasValue ? CourseLength.Value.ToString() : null;
+
+            enrichmentModel.CourseLength = courseLength;
+            enrichmentModel.FeeUkEu = FeeUkEu;
+            enrichmentModel.FeeInternational = FeeInternational;
+            enrichmentModel.FeeDetails = FeeDetails;
+            enrichmentModel.FinancialSupport = FinancialSupport;
+        }
     }
 }

--- a/src/ui/ViewModels/CourseRequirementsEnrichmentViewModel.cs
+++ b/src/ui/ViewModels/CourseRequirementsEnrichmentViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ManageCourses.ApiClient;
 
 namespace GovUk.Education.ManageCourses.Ui.ViewModels
 {
@@ -17,5 +18,17 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         public CourseRouteDataViewModel RouteData { get; set; }
 
         public CourseInfoViewModel CourseInfo { get; set; }
+
+        public bool IsEmpty() =>
+            string.IsNullOrEmpty(Qualifications) &&
+            string.IsNullOrEmpty(PersonalQualities) &&
+            string.IsNullOrEmpty(OtherRequirements);
+
+        public void MapInto(ref CourseEnrichmentModel enrichmentModel)
+        {        
+            enrichmentModel.Qualifications = Qualifications;
+            enrichmentModel.PersonalQualities = PersonalQualities;
+            enrichmentModel.OtherRequirements = OtherRequirements;
+        }
     }
 }

--- a/src/ui/ViewModels/CourseSalaryEnrichmentViewModel.cs
+++ b/src/ui/ViewModels/CourseSalaryEnrichmentViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ManageCourses.ApiClient;
 using GovUk.Education.ManageCourses.Ui.ViewModels.Enums;
 
 namespace GovUk.Education.ManageCourses.Ui.ViewModels
@@ -14,5 +15,17 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         public CourseRouteDataViewModel RouteData { get; set; }
 
         public CourseInfoViewModel CourseInfo { get; set; }
+
+        public bool IsEmpty() =>
+            !CourseLength.HasValue &&
+            string.IsNullOrEmpty(SalaryDetails);
+
+        public void MapInto(ref CourseEnrichmentModel enrichmentModel)
+        {
+            var courseLength = CourseLength.HasValue ? CourseLength.Value.ToString() : null;
+
+            enrichmentModel.CourseLength = courseLength;
+            enrichmentModel.SalaryDetails = SalaryDetails;
+        }
     }
 }

--- a/src/ui/ViewModels/ICourseEnrichmentViewModel.cs
+++ b/src/ui/ViewModels/ICourseEnrichmentViewModel.cs
@@ -1,6 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ManageCourses.ApiClient;
+
 namespace GovUk.Education.ManageCourses.Ui.ViewModels
 {
-    public interface ICourseEnrichmentViewModel { }
+    public interface ICourseEnrichmentViewModel 
+    { 
+        bool IsEmpty();
+        void MapInto(ref CourseEnrichmentModel enrichmentModel);
+    }
 }


### PR DESCRIPTION
### Context

https://trello.com/c/1NOkp4WO/220-saving-an-empty-enrichment-shouldnt-create-a-new-draft#

### Changes proposed in this pull request

For organisations and each course enrichment page:

- Before save, check if a draft already exists
- If no draft exists, check if ViewModel is empty
- Don't create a new draft if ViewModel is empty

Additionally, I have refactored the Course view model to enrichment model mapping to be polymorphic as implied by the `ICourseEnrichmentViewModel` interface.

### Guidance to review

`CourseController.SaveEnrichment` and `OrganisationController.SaveOrgansation` are the key changes, everything else is just plumbing. 