### PR TITLE
Remove "in addition to" statement

### DIFF
--- a/src/ui/Views/Course/Requirements.cshtml
+++ b/src/ui/Views/Course/Requirements.cshtml
@@ -18,7 +18,7 @@
         </h1>
         @Html.Partial("ErrorSummary")
         <h3 class="govuk-heading-l">Qualifications needed</h3>
-        <p class="govuk-body">State the minimum academic qualifications needed for this course, in addition to the basic national requirements.</p>
+        <p class="govuk-body">State the minimum academic qualifications needed for this course.</p>
         <div class="govuk-character-count" data-module="character-count" data-maxwords="100">
           <div id="Qualifications-wrapper" class="@(qualifications ? " govuk-form-group--error " : " ")">
             <label asp-for="Qualifications" class="govuk-label govuk-!-font-weight-bold">Qualifications needed</label>


### PR DESCRIPTION
### Context

Providers should state if the courses only require the national minimum, and what that minimum is.

This is an MVP change. We need to iterate the design for better capture of national minimum requirements.

See user research relating to this change:
https://lookback.io/watch/dujimh9gzaKrRAFBu?t=35m28s
