### PR TITLE
Add details about previewing organisation info

### DIFF
--- a/ManageCoursesUi.Tests/Controllers/OrganisationControllerTests.cs
+++ b/ManageCoursesUi.Tests/Controllers/OrganisationControllerTests.cs
@@ -55,7 +55,7 @@ namespace ManageCoursesUi.Tests
 
             apiMock.Setup(x => x.GetOrganisations()).ReturnsAsync(orgs);
 
-            var controller = new OrganisationController(apiMock.Object);
+            var controller = new OrganisationController(apiMock.Object, new MockFeatureFlags());
 
             var result = await controller.Courses(ucasCode);
 
@@ -95,7 +95,7 @@ namespace ManageCoursesUi.Tests
             apiMock.Setup(x => x.GetOrganisations())
                 .ReturnsAsync(orgs);
 
-            var controller = new OrganisationController(apiMock.Object);
+            var controller = new OrganisationController(apiMock.Object, new MockFeatureFlags());
 
             var result = await controller.RequestAccess(ucasCode);
 
@@ -132,7 +132,7 @@ namespace ManageCoursesUi.Tests
             apiMock.Setup(x => x.GetOrganisations())
                 .ReturnsAsync(orgs);
 
-            var controller = new OrganisationController(apiMock.Object);
+            var controller = new OrganisationController(apiMock.Object, new MockFeatureFlags());
             controller.ModelState.AddModelError("you", "failed");
             var result = await controller.RequestAccessPost(ucasCode, new RequestAccessViewModel());
 
@@ -159,7 +159,7 @@ namespace ManageCoursesUi.Tests
 
             var tempDataMock = new Mock<ITempDataDictionary>();
 
-            var controller = new OrganisationController(apiMock.Object);
+            var controller = new OrganisationController(apiMock.Object, new MockFeatureFlags());
             controller.TempData = tempDataMock.Object;
 
             var result = await controller.RequestAccessPost(ucasCode, viewModel);
@@ -237,7 +237,7 @@ namespace ManageCoursesUi.Tests
             apiMock.Setup(x => x.GetEnrichmentOrganisation(ucasCode))
                 .ReturnsAsync(ucasInstitutionEnrichmentGetModel);
 
-            var controller = new OrganisationController(apiMock.Object);
+            var controller = new OrganisationController(apiMock.Object, new MockFeatureFlags());
 
             var result = await controller.About(ucasCode);
 
@@ -304,7 +304,7 @@ namespace ManageCoursesUi.Tests
                 It.IsAny<string>(),
                 It.IsAny<Object>()));
 
-            var controller = new OrganisationController(apiMock.Object);
+            var controller = new OrganisationController(apiMock.Object, new MockFeatureFlags());
 
             controller.ObjectValidator = objectValidator.Object;
 
@@ -369,7 +369,7 @@ namespace ManageCoursesUi.Tests
                 It.IsAny<string>(),
                 It.IsAny<Object>()));
 
-            var controller = new OrganisationController(apiMock.Object);
+            var controller = new OrganisationController(apiMock.Object, new MockFeatureFlags());
             controller.ObjectValidator = objectValidator.Object;
 
             controller.TempData = new Mock<ITempDataDictionary>().Object;
@@ -432,7 +432,7 @@ namespace ManageCoursesUi.Tests
 
             apiMock.Setup(x => x.PublishEnrichmentOrganisation(ucasCode))
                 .ReturnsAsync(true);
-            var controller = new OrganisationController(apiMock.Object);
+            var controller = new OrganisationController(apiMock.Object, new MockFeatureFlags());
             controller.ObjectValidator = objectValidator.Object;
 
             controller.TempData = new Mock<ITempDataDictionary>().Object;
@@ -515,7 +515,7 @@ namespace ManageCoursesUi.Tests
 
             apiMock.Setup(x => x.PublishEnrichmentOrganisation(ucasCode))
                 .ReturnsAsync(true);
-            var controller = new OrganisationControllerMockedValidation(apiMock.Object);
+            var controller = new OrganisationControllerMockedValidation(apiMock.Object, new MockFeatureFlags());
 
             var result = await controller.AboutPost(ucasCode, viewModel);
 
@@ -592,7 +592,7 @@ namespace ManageCoursesUi.Tests
                 It.IsAny<string>(),
                 It.IsAny<Object>()));
 
-            var controller = new OrganisationController(apiMock.Object);
+            var controller = new OrganisationController(apiMock.Object, new MockFeatureFlags());
 
             controller.ObjectValidator = objectValidator.Object;
 
@@ -615,6 +615,15 @@ namespace ManageCoursesUi.Tests
             Assert.AreEqual(exceed100Words, organisationViewModel.AboutTrainingProviders.First(x => x.InstitutionCode == ucasCode + 1).Description);
             Assert.AreEqual(institutionName, organisationViewModel.AboutTrainingProviders.First(x => x.InstitutionCode == ucasCode + 1).InstitutionName);
 
+        }
+
+        private class MockFeatureFlags : IFeatureFlags
+        {
+            public bool ShowCoursePreview => true;
+
+            public bool ShowCoursePublish => true;
+
+            public bool ShowCourseLiveView => true;
         }
     }
 }

--- a/ManageCoursesUi.Tests/Mocks/OrganisationControllerMockedValidation.cs
+++ b/ManageCoursesUi.Tests/Mocks/OrganisationControllerMockedValidation.cs
@@ -10,7 +10,7 @@ namespace ManageCoursesUi.Tests.Mocks
 {
     public class OrganisationControllerMockedValidation : OrganisationController
     {
-        public OrganisationControllerMockedValidation(IManageApi manageApi) : base(manageApi) { }
+        public OrganisationControllerMockedValidation(IManageApi manageApi, IFeatureFlags featureFlags) : base(manageApi, featureFlags) { }
         public override bool TryValidateModel(object model)
         {
             this.ModelState.AddModelError("you", "failed");

--- a/src/ui/Controllers/OrganisationController.cs
+++ b/src/ui/Controllers/OrganisationController.cs
@@ -19,12 +19,12 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
     public class OrganisationController : CommonAttributesControllerBase
     {
         private readonly IManageApi _manageApi;
-        private readonly IFeatureFlags featureFlags;
+        private readonly IFeatureFlags _featureFlags;
 
         public OrganisationController(IManageApi manageApi, IFeatureFlags featureFlags)
         {
             _manageApi = manageApi;
-            this.featureFlags = featureFlags;
+            this._featureFlags = featureFlags;
         }
 
         [Route("{ucasCode}/courses")]
@@ -171,7 +171,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                 LastPublishedTimestampUtc = ucasInstitutionEnrichmentGetModel.LastPublishedTimestampUtc,
                 Status = ucasInstitutionEnrichmentGetModel.Status,
                 PublishOrganisation = false,
-                AllowPreview = featureFlags.ShowCoursePreview
+                AllowPreview = _featureFlags.ShowCoursePreview
             };
 
             return result;

--- a/src/ui/Controllers/OrganisationController.cs
+++ b/src/ui/Controllers/OrganisationController.cs
@@ -19,10 +19,12 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
     public class OrganisationController : CommonAttributesControllerBase
     {
         private readonly IManageApi _manageApi;
+        private readonly IFeatureFlags featureFlags;
 
-        public OrganisationController(IManageApi manageApi)
+        public OrganisationController(IManageApi manageApi, IFeatureFlags featureFlags)
         {
             _manageApi = manageApi;
+            this.featureFlags = featureFlags;
         }
 
         [Route("{ucasCode}/courses")]
@@ -168,7 +170,8 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                 TrainWithDisability = enrichmentModel.TrainWithDisability,
                 LastPublishedTimestampUtc = ucasInstitutionEnrichmentGetModel.LastPublishedTimestampUtc,
                 Status = ucasInstitutionEnrichmentGetModel.Status,
-                PublishOrganisation = false
+                PublishOrganisation = false,
+                AllowPreview = featureFlags.ShowCoursePreview
             };
 
             return result;

--- a/src/ui/ViewModels/OrganisationViewModel.cs
+++ b/src/ui/ViewModels/OrganisationViewModel.cs
@@ -30,5 +30,7 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         public EnumStatus Status { get; set; }
 
         public bool PublishOrganisation { get; set; }
+
+        public bool AllowPreview { get; set; }
     }
 }

--- a/src/ui/Views/Organisation/About.cshtml
+++ b/src/ui/Views/Organisation/About.cshtml
@@ -92,22 +92,31 @@
             <strong class="govuk-tag govuk-tag--blank">Empty</strong>
             <p class="govuk-body">You need to complete and publish this information.</p>
 
+            <hr class="related__section-break" />
+            <h4 class="govuk-heading-m">Preview</h4>
+            <p class="govuk-body">This information will show on all your courses.</p>
+            <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+
             <hr class="related__section-break">
             <h4 class="govuk-heading-m">Publish</h4>
-            <p class="govuk-body">New information will show on all @Model.TabViewModel.OrganisationName courses.</p>
+            <p class="govuk-body">Applicants will see published information from October.</p>
 
             <form asp-controller="Organisation" asp-action="about" method="post">
               <input type="submit" class="govuk-button" value="Publish" />
-              <input type="hidden" asp-for="@Model.PublishOrganisation" value="true"></input>
+              <input type="hidden" asp-for="@Model.PublishOrganisation" value="true" />
             </form>
             break;
           case WorkflowStatus.InitialDraft :
             <strong class="govuk-tag govuk-tag--draft">Draft</strong>
             <p class="govuk-body">You have unpublished changes.</p>
 
+            <hr class="related__section-break" />
+            <h4 class="govuk-heading-m">Preview</h4>
+            <p class="govuk-body">This information will show on all your courses.</p>
+            <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+
             <hr class="related__section-break">
             <h4 class="govuk-heading-m">Publish</h4>
-            <p class="govuk-body">This information will show on all your courses.</p>
             <p class="govuk-body">Applicants will see published information from October.</p>
 
             <form asp-controller="Organisation" asp-action="about" method="post">
@@ -117,8 +126,8 @@
             break;
           case WorkflowStatus.Published :
             <strong class="govuk-tag govuk-tag--published">Published</strong>
-            <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
             <p class="govuk-body">Applicants will see this on all your courses from October.</p>
+            <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
 
             break;
           case WorkflowStatus.SubsequentDraft :
@@ -126,9 +135,13 @@
             <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
             <p class="govuk-body">You have unpublished changes.</p>
 
+            <hr class="related__section-break" />
+            <h4 class="govuk-heading-m">Preview</h4>
+            <p class="govuk-body">This information will show on all your courses.</p>
+            <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+
             <hr class="related__section-break">
             <h4 class="govuk-heading-m">Publish</h4>
-            <p class="govuk-body">This information will show on all your courses.</p>
             <p class="govuk-body">Applicants will see published information from October.</p>
 
             <form asp-controller="Organisation" asp-action="about" method="post">
@@ -141,9 +154,14 @@
             <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
             <p class="govuk-body">You have unpublished changes.</p>
 
+            <hr class="related__section-break" />
+            <h4 class="govuk-heading-m">Preview</h4>
+            <p class="govuk-body">This information will show on all your courses.</p>
+            <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+
             <hr class="related__section-break">
             <h4 class="govuk-heading-m">Publish</h4>
-            <p class="govuk-body">New information will show on all @Model.TabViewModel.OrganisationName courses.</p>
+            <p class="govuk-body">Applicants will see published information from October.</p>
 
             <form asp-controller="Organisation" asp-action="about" method="post">
               <input type="hidden" asp-for="@Model.PublishOrganisation" value="true" />

--- a/src/ui/Views/Organisation/About.cshtml
+++ b/src/ui/Views/Organisation/About.cshtml
@@ -92,10 +92,13 @@
             <strong class="govuk-tag govuk-tag--blank">Empty</strong>
             <p class="govuk-body">You need to complete and publish this information.</p>
 
-            <hr class="related__section-break" />
-            <h4 class="govuk-heading-m">Preview</h4>
-            <p class="govuk-body">This information will show on all your courses.</p>
-            <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+            @if (Model.AllowPreview)
+            {
+              <hr class="related__section-break" />
+              <h4 class="govuk-heading-m">Preview</h4>
+              <p class="govuk-body">This information will show on all your courses.</p>
+              <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+            }
 
             <hr class="related__section-break">
             <h4 class="govuk-heading-m">Publish</h4>
@@ -110,10 +113,13 @@
             <strong class="govuk-tag govuk-tag--draft">Draft</strong>
             <p class="govuk-body">You have unpublished changes.</p>
 
-            <hr class="related__section-break" />
-            <h4 class="govuk-heading-m">Preview</h4>
-            <p class="govuk-body">This information will show on all your courses.</p>
-            <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+            @if (Model.AllowPreview)
+            {
+              <hr class="related__section-break" />
+              <h4 class="govuk-heading-m">Preview</h4>
+              <p class="govuk-body">This information will show on all your courses.</p>
+              <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+            }
 
             <hr class="related__section-break">
             <h4 class="govuk-heading-m">Publish</h4>
@@ -135,10 +141,13 @@
             <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
             <p class="govuk-body">You have unpublished changes.</p>
 
-            <hr class="related__section-break" />
-            <h4 class="govuk-heading-m">Preview</h4>
-            <p class="govuk-body">This information will show on all your courses.</p>
-            <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+            @if (Model.AllowPreview)
+            {
+              <hr class="related__section-break" />
+              <h4 class="govuk-heading-m">Preview</h4>
+              <p class="govuk-body">This information will show on all your courses.</p>
+              <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+            }
 
             <hr class="related__section-break">
             <h4 class="govuk-heading-m">Publish</h4>
@@ -153,11 +162,14 @@
             <strong class="govuk-tag govuk-tag--draft">Empty</strong>
             <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
             <p class="govuk-body">You have unpublished changes.</p>
-
-            <hr class="related__section-break" />
-            <h4 class="govuk-heading-m">Preview</h4>
-            <p class="govuk-body">This information will show on all your courses.</p>
-            <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+            
+            @if (Model.AllowPreview)
+            {
+              <hr class="related__section-break" />
+              <h4 class="govuk-heading-m">Preview</h4>
+              <p class="govuk-body">This information will show on all your courses.</p>
+              <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+            }
 
             <hr class="related__section-break">
             <h4 class="govuk-heading-m">Publish</h4>


### PR DESCRIPTION
The way of previewing org info is quite contrived. Before we make a better org preview feature, indicate to users how they can see their org info before publishing.

TODO:
I need someone to wrap the preview text in the correct feature flag logic so that we only show the "how to preview" text to users who can enrich courses and preview them.
