### PR TITLE
Add context to success messages

### DIFF
--- a/ManageCoursesUi.Tests/CourseControllerTests.cs
+++ b/ManageCoursesUi.Tests/CourseControllerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using GovUk.Education.ManageCourses.ApiClient;
 using GovUk.Education.ManageCourses.Ui;
@@ -13,9 +14,11 @@ using ManageCoursesUi.Tests.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Moq;
 using NUnit.Framework;
+
 
 namespace ManageCoursesUi.Tests
 {
@@ -365,9 +368,16 @@ namespace ManageCoursesUi.Tests
             manageApi.Setup(x => x.GetEnrichmentCourse(TestHelper.InstitutionCode, TestHelper.TargetedUcasCode)).ReturnsAsync(ucasCourseEnrichmentGetModel);
 
             var tempDataMock = new Mock<ITempDataDictionary>();
+            var urlHelperMock = new Mock<IUrlHelper>();
+
+            var previewLink = "preview-link";
+            
+            Expression<Func<IUrlHelper, string>> urlSetup = url => url.Action(It.Is<UrlActionContext>(uac => uac.Action == "Preview"));
+            urlHelperMock.Setup(urlSetup).Returns(previewLink);
 
             var controller = new CourseController(manageApi.Object, new CourseMapper(), new SearchAndCompareUrlService("http://www.example.com"), new MockFeatureFlags());
             controller.TempData = tempDataMock.Object;
+            controller.Url = urlHelperMock.Object;
             var result = await controller.AboutPost(TestHelper.InstitutionCode, TestHelper.AccreditedProviderId, TestHelper.TargetedUcasCode, viewModel);
 
             var redirectToActionResult = result as RedirectToActionResult;
@@ -378,6 +388,11 @@ namespace ManageCoursesUi.Tests
 
             tempDataMock.Verify(x => x.Add("MessageType", "success"), Times.Once);
             tempDataMock.Verify(x => x.Add("MessageTitle", "Your changes have been saved"), Times.Once);
+            tempDataMock.Verify(x => x.Add("MessageBodyHtml", $@"
+                    <p class=""govuk-body"">
+                        <a href='{previewLink}'>Preview your course</a>
+                        to check for mistakes before publishing.
+                    </p>"), Times.Once);
 
             var routeValues = redirectToActionResult.RouteValues;
 
@@ -468,9 +483,18 @@ namespace ManageCoursesUi.Tests
             manageApi.Setup(x => x.GetEnrichmentCourse(TestHelper.InstitutionCode, TestHelper.TargetedUcasCode)).ReturnsAsync(ucasCourseEnrichmentGetModel);
 
             var tempDataMock = new Mock<ITempDataDictionary>();
+            var urlHelperMock = new Mock<IUrlHelper>();
+
+            var previewLink = "preview-link";
+
+            Expression<Func<IUrlHelper, string>> urlSetup = url => url.Action(It.Is<UrlActionContext>(uac => uac.Action == "Preview"));
+            urlHelperMock.Setup(urlSetup).Returns(previewLink);
 
             var controller = new CourseController(manageApi.Object, new CourseMapper(), new SearchAndCompareUrlService("http://www.example.com"), new MockFeatureFlags());
+
             controller.TempData = tempDataMock.Object;
+            controller.Url = urlHelperMock.Object;
+
             var result = await controller.RequirementsPost(TestHelper.InstitutionCode, TestHelper.AccreditedProviderId, TestHelper.TargetedUcasCode, viewModel);
 
             var redirectToActionResult = result as RedirectToActionResult;
@@ -481,6 +505,11 @@ namespace ManageCoursesUi.Tests
 
             tempDataMock.Verify(x => x.Add("MessageType", "success"), Times.Once);
             tempDataMock.Verify(x => x.Add("MessageTitle", "Your changes have been saved"), Times.Once);
+            tempDataMock.Verify(x => x.Add("MessageBodyHtml", $@"
+                    <p class=""govuk-body"">
+                        <a href='{previewLink}'>Preview your course</a>
+                        to check for mistakes before publishing.
+                    </p>"), Times.Once);
 
             var routeValues = redirectToActionResult.RouteValues;
 
@@ -573,10 +602,18 @@ namespace ManageCoursesUi.Tests
             manageApi.Setup(x => x.GetEnrichmentCourse(TestHelper.InstitutionCode, TestHelper.TargetedUcasCode)).ReturnsAsync(ucasCourseEnrichmentGetModel);
 
             var tempDataMock = new Mock<ITempDataDictionary>();
+            var urlHelperMock = new Mock<IUrlHelper>();
+
+            var previewLink = "preview-link";
+
+            Expression<Func<IUrlHelper, string>> urlSetup = url => url.Action(It.Is<UrlActionContext>(uac => uac.Action == "Preview"));
+            urlHelperMock.Setup(urlSetup).Returns(previewLink);
 
             var controller = new CourseController(manageApi.Object, new CourseMapper(), new SearchAndCompareUrlService("http://www.example.com"), new MockFeatureFlags());
 
             controller.TempData = tempDataMock.Object;
+            controller.Url = urlHelperMock.Object;
+
             var result = await controller.SalaryPost(TestHelper.InstitutionCode, TestHelper.AccreditedProviderId, TestHelper.TargetedUcasCode, viewModel);
 
             var redirectToActionResult = result as RedirectToActionResult;
@@ -587,6 +624,11 @@ namespace ManageCoursesUi.Tests
 
             tempDataMock.Verify(x => x.Add("MessageType", "success"), Times.Once);
             tempDataMock.Verify(x => x.Add("MessageTitle", "Your changes have been saved"), Times.Once);
+            tempDataMock.Verify(x => x.Add("MessageBodyHtml", $@"
+                    <p class=""govuk-body"">
+                        <a href='{previewLink}'>Preview your course</a>
+                        to check for mistakes before publishing.
+                    </p>"), Times.Once);
 
             var routeValues = redirectToActionResult.RouteValues;
 
@@ -685,10 +727,18 @@ namespace ManageCoursesUi.Tests
             manageApi.Setup(x => x.GetEnrichmentCourse(TestHelper.InstitutionCode, TestHelper.TargetedUcasCode)).ReturnsAsync(ucasCourseEnrichmentGetModel);
 
             var tempDataMock = new Mock<ITempDataDictionary>();
+            var urlHelperMock = new Mock<IUrlHelper>();
+
+            var previewLink = "preview-link";
+
+            Expression<Func<IUrlHelper, string>> urlSetup = url => url.Action(It.Is<UrlActionContext>(uac => uac.Action == "Preview"));
+            urlHelperMock.Setup(urlSetup).Returns(previewLink);
 
             var controller = new CourseController(manageApi.Object, new CourseMapper(), new SearchAndCompareUrlService("http://www.example.com"), new MockFeatureFlags());
 
             controller.TempData = tempDataMock.Object;
+            controller.Url = urlHelperMock.Object;
+
             var result = await controller.FeesPost(TestHelper.InstitutionCode, TestHelper.AccreditedProviderId, TestHelper.TargetedUcasCode, viewModel);
 
             var redirectToActionResult = result as RedirectToActionResult;
@@ -699,6 +749,11 @@ namespace ManageCoursesUi.Tests
 
             tempDataMock.Verify(x => x.Add("MessageType", "success"), Times.Once);
             tempDataMock.Verify(x => x.Add("MessageTitle", "Your changes have been saved"), Times.Once);
+            tempDataMock.Verify(x => x.Add("MessageBodyHtml", $@"
+                    <p class=""govuk-body"">
+                        <a href='{previewLink}'>Preview your course</a>
+                        to check for mistakes before publishing.
+                    </p>"), Times.Once);
 
             var routeValues = redirectToActionResult.RouteValues;
 

--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -115,9 +115,9 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
             return View(new SearchAndCompare.UI.Shared.ViewModels.CourseDetailsViewModel
             {
                 AboutYourOrgLink = Url.Action("About", "Organisation", new { ucasCode = instCode }),
-                    PreviewMode = true,
-                    Course = course,
-                    Finance = new FinanceViewModel(course, new FeeCaps())
+                PreviewMode = true,
+                Course = course,
+                Finance = new FinanceViewModel(course, new FeeCaps())
             });
         }
 
@@ -332,41 +332,41 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                 new CourseVariantViewModel
                 {
                     Name = course.Name,
-                        Type = course.GetCourseVariantType(),
-                        Accrediting = course.AccreditingProviderName,
-                        ProviderCode = course.AccreditingProviderId,
-                        ProgrammeCode = course.CourseCode,
-                        UcasCode = course.InstCode,
-                        AgeRange = course.AgeRange,
-                        Route = course.ProgramType,
-                        Qualifications = course.ProfpostFlag,
-                        StudyMode = course.StudyMode,
-                        Subjects = course.Subjects,
-                        Status = course.GetCourseStatus(),
-                        Schools = course.Schools.Select(campus =>
-                        {
-                            var addressLines = (new List<string>()
-                                {
+                    Type = course.GetCourseVariantType(),
+                    Accrediting = course.AccreditingProviderName,
+                    ProviderCode = course.AccreditingProviderId,
+                    ProgrammeCode = course.CourseCode,
+                    UcasCode = course.InstCode,
+                    AgeRange = course.AgeRange,
+                    Route = course.ProgramType,
+                    Qualifications = course.ProfpostFlag,
+                    StudyMode = course.StudyMode,
+                    Subjects = course.Subjects,
+                    Status = course.GetCourseStatus(),
+                    Schools = course.Schools.Select(campus =>
+                    {
+                        var addressLines = (new List<string>()
+                            {
                                     campus.Address1,
                                         campus.Address2,
                                         campus.Address3,
                                         campus.Address4,
                                         campus.PostCode
-                                })
-                                .Where(line => !String.IsNullOrEmpty(line));
+                            })
+                            .Where(line => !String.IsNullOrEmpty(line));
 
-                            var address = addressLines.Count() > 0 ? addressLines.Where(line => !String.IsNullOrEmpty(line))
-                                .Aggregate((current, next) => current + ", " + next) : "";
+                        var address = addressLines.Count() > 0 ? addressLines.Where(line => !String.IsNullOrEmpty(line))
+                            .Aggregate((current, next) => current + ", " + next) : "";
 
-                            return new SchoolViewModel
-                            {
-                                ApplicationsAcceptedFrom = campus.ApplicationsAcceptedFrom,
-                                    Code = campus.Code,
-                                    LocationName = campus.LocationName,
-                                    Address = address,
-                                    Status = campus.Status
-                            };
-                        })
+                        return new SchoolViewModel
+                        {
+                            ApplicationsAcceptedFrom = campus.ApplicationsAcceptedFrom,
+                            Code = campus.Code,
+                            LocationName = campus.LocationName,
+                            Address = address,
+                            Status = campus.Status
+                        };
+                    })
                 };
 
             var isSalary = course.ProgramType.Equals("SS", StringComparison.InvariantCultureIgnoreCase);
@@ -445,8 +445,8 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
             return new CourseRouteDataViewModel
             {
                 InstCode = instCode,
-                    AccreditingProviderId = accreditingProviderId,
-                    UcasCode = ucasCode
+                AccreditingProviderId = accreditingProviderId,
+                UcasCode = ucasCode
             };
         }
     }

--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -82,7 +82,18 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
 
             if (result)
             {
-                SetSucessMessage("Your course has been published");
+                TempData.Add("MessageType", "success");
+                TempData.Add("MessageTitle", "Your course has been published");
+                var searchUrl = searchAndCompareUrlService.GetCoursePageUri(course.InstCode, course.CourseCode);
+                if (featureFlags.ShowCourseLiveView)
+                {
+                    TempData.Add("MessageBodyHtml", $@"
+                        <p class=""govuk-body"">
+                            See how this course looks to applicants:
+                            <br />
+                            <a href='{searchUrl}'>View on website</a>
+                        </p>");
+                }
             }
 
             return RedirectToAction("Variants", new { instCode, accreditingProviderId, ucasCode });
@@ -159,7 +170,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
 
             if (await SaveEnrichment(instCode, ucasCode, viewModel))
             {
-                SetSucessMessage();
+                CourseSavedMessage();
             }
 
             return RedirectToAction("Variants", new { instCode, accreditingProviderId, ucasCode });
@@ -204,7 +215,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
 
             if (await SaveEnrichment(instCode, ucasCode, viewModel))
             {
-                SetSucessMessage();
+                CourseSavedMessage();
             }
 
             return RedirectToAction("Variants", new { instCode, accreditingProviderId, ucasCode });
@@ -246,7 +257,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
             }
             if (await SaveEnrichment(instCode, ucasCode, viewModel))
             {
-                SetSucessMessage();
+                CourseSavedMessage();
             }
             return RedirectToAction("Variants", new { instCode, accreditingProviderId, ucasCode });
         }
@@ -290,7 +301,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
             }
             if (await SaveEnrichment(instCode, ucasCode, viewModel))
             {
-                SetSucessMessage();
+                CourseSavedMessage();
             }
             return RedirectToAction("Variants", new { instCode, accreditingProviderId, ucasCode });
         }
@@ -319,11 +330,19 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
             if (string.IsNullOrEmpty(ucasCode)) { throw new ArgumentNullException(ucasCode, "ucasCode cannot be null or empty"); }
         }
 
-        private void SetSucessMessage(string message = null)
+        private void CourseSavedMessage()
         {
             TempData.Add("MessageType", "success");
-            TempData.Add("MessageTitle", message ?? "Your changes have been saved");
-            TempData.Add("MessageBodyHtml", "<p class=\"govuk-body\">Preview your course to check for mistakes before publishing.</p>");
+            TempData.Add("MessageTitle", "Your changes have been saved");
+            if (featureFlags.ShowCoursePreview)
+            {
+                var previewLink = Url.Action("Preview");
+                TempData.Add("MessageBodyHtml", $@"
+                    <p class=""govuk-body"">
+                        <a href='{previewLink}'>Preview your course</a>
+                        to check for mistakes before publishing.
+                    </p>");
+            }
         }
 
         private VariantViewModel LoadViewModel(UserOrganisation org, ApiClient.Course course, bool multipleOrganisations, UcasCourseEnrichmentGetModel ucasCourseEnrichmentGetModel, CourseRouteDataViewModel routeData)

--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -323,7 +323,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         {
             TempData.Add("MessageType", "success");
             TempData.Add("MessageTitle", message ?? "Your changes have been saved");
-            TempData.Add("MessageBodyHtml", "<p class=\"govuk-body\">Preview your course to check for mistakes before publishing.</p>";);
+            TempData.Add("MessageBodyHtml", "<p class=\"govuk-body\">Preview your course to check for mistakes before publishing.</p>");
         }
 
         private VariantViewModel LoadViewModel(UserOrganisation org, ApiClient.Course course, bool multipleOrganisations, UcasCourseEnrichmentGetModel ucasCourseEnrichmentGetModel, CourseRouteDataViewModel routeData)

--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -323,6 +323,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         {
             TempData.Add("MessageType", "success");
             TempData.Add("MessageTitle", message ?? "Your changes have been saved");
+            TempData.Add("MessageBodyHtml", "<p class=\"govuk-body\">Preview your course to check for mistakes before publishing.</p>";);
         }
 
         private VariantViewModel LoadViewModel(UserOrganisation org, ApiClient.Course course, bool multipleOrganisations, UcasCourseEnrichmentGetModel ucasCourseEnrichmentGetModel, CourseRouteDataViewModel routeData)

--- a/src/ui/Controllers/OrganisationController.cs
+++ b/src/ui/Controllers/OrganisationController.cs
@@ -210,6 +210,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
 
                     TempData["MessageType"] = "success";
                     TempData["MessageTitle"] = "Your changes have been published";
+                    TempData["MessageBodyHtml"] = "<p class=\"govuk-body\">Applicants will see this on all your courses from October.</p>";
 
                     return RedirectToAction("About", new { ucasCode });
                 }

--- a/src/ui/Controllers/OrganisationController.cs
+++ b/src/ui/Controllers/OrganisationController.cs
@@ -108,10 +108,10 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
             await _manageApi.LogAccessRequest(new AccessRequest()
             {
                 FirstName = model.FirstName,
-                    LastName = model.LastName,
-                    EmailAddress = model.EmailAddress,
-                    Organisation = model.Organisation,
-                    Reason = model.Reason,
+                LastName = model.LastName,
+                EmailAddress = model.EmailAddress,
+                Organisation = model.Organisation,
+                Reason = model.Reason,
             });
 
             this.TempData.Add("RequestAccess_To_Name", $"{model.FirstName} {model.LastName}");
@@ -141,7 +141,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                             var aboutTrainingProviders = (model.AboutTrainingProviders ?? new List<TrainingProviderViewModel>());
 
                             description = aboutTrainingProviders.FirstOrDefault(
-                                atp =>(atp.InstitutionCode.Equals(x.AccreditingProviderId, StringComparison.InvariantCultureIgnoreCase)))?.Description ?? description;
+                                atp => (atp.InstitutionCode.Equals(x.AccreditingProviderId, StringComparison.InvariantCultureIgnoreCase)))?.Description ?? description;
                         }
 
                         var tpvm = new TrainingProviderViewModel()
@@ -246,7 +246,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                     model.AboutTrainingProviders.Select(x => new AccreditingProviderEnrichment
                     {
                         UcasInstitutionCode = x.InstitutionCode,
-                            Description = x.Description
+                        Description = x.Description
                     }));
 
                 if (enrichmentModel == null)

--- a/src/ui/Controllers/OrganisationController.cs
+++ b/src/ui/Controllers/OrganisationController.cs
@@ -273,6 +273,10 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
 
                 TempData["MessageType"] = "success";
                 TempData["MessageTitle"] = "Your changes have been saved";
+                if (_featureFlags.ShowCoursePreview)
+                {
+                    TempData["MessageBodyHtml"] = "<p class=\"govuk-body\">Preview any course to see how it will look to applicants.</p>";
+                }
 
                 return RedirectToAction("About", "Organisation", new { ucasCode });
             }

--- a/src/ui/Views/Course/Variants.cshtml
+++ b/src/ui/Views/Course/Variants.cshtml
@@ -11,10 +11,10 @@
 
 <a href="@Url.Action("Courses", "Organisation", new {ucasCode = Model.Course.UcasCode})" class="govuk-back-link">Back</a>
 
-@await Html.PartialAsync("~/Views/Shared/_Alerts.cshtml")
-@await Html.PartialAsync("Shared/ErrorSummaryCourseOverview.cshtml")
-
 <main role="main" class="govuk-main-wrapper" id="main-content">
+    @await Html.PartialAsync("~/Views/Shared/_Alerts.cshtml")
+    @await Html.PartialAsync("Shared/ErrorSummaryCourseOverview.cshtml")
+
   <h1 class="govuk-heading-xl">
     <span class="govuk-caption-xl">@Model.Course.Type</span>
     @Model.Course.Name (@Model.Course.ProgrammeCode)

--- a/src/ui/Views/Shared/_Alerts.cshtml
+++ b/src/ui/Views/Shared/_Alerts.cshtml
@@ -12,7 +12,7 @@
     @if (body != null)
     {
       <div class="govuk-@type-summary__body">
-        <p clas="govuk-body">@Html.Raw(body)</p>
+        @Html.Raw(body)
       </div>
     }
   </div>


### PR DESCRIPTION
* Tell users when their content will be seen by applicants
* Prompt users to preview after saving

## TODO (or things I couldn't do)

* [x] Run this app to test it looks ok
* [x] When a course is published it should show  a success message
* [x] When saving about your org, add a preview prompt – it needs to depend on feature flags
* [x] When the preview prompt shows on a course, the prompt should  link to the preview
