### PR TITLE
Remove margin from govuk-tag

### DIFF
--- a/src/ui/Assets/Styles/components/_publish-tags.scss
+++ b/src/ui/Assets/Styles/components/_publish-tags.scss
@@ -1,17 +1,16 @@
-.govuk-tag {
-  margin-bottom: govuk-spacing(3);
-}
-
 .govuk-tag--blank {
   background: govuk-colour("white");
   color: govuk-colour("grey-1");
   border: 2px solid govuk-colour("grey-2");
+  margin-bottom: govuk-spacing(3);
 }
 
 .govuk-tag--draft {
   background: govuk-colour("orange");
+  margin-bottom: govuk-spacing(3);
 }
 
 .govuk-tag--published {
   background: govuk-colour("green");
+  margin-bottom: govuk-spacing(3);
 }


### PR DESCRIPTION
### Context
The publish status work introduced a bottom margin to the service phase tag

### Changes proposed in this pull request
Move bottom margin to specific publish tags

### Guidance to review
<img width="945" alt="screen shot 2018-09-03 at 11 03 24" src="https://user-images.githubusercontent.com/3071606/44980886-011e7400-af69-11e8-9600-80e81d4ce416.png">
