### PR TITLE
Fix breadcrumb and back links for orgs

### DIFF
--- a/src/ui/Views/Organisation/About.cshtml
+++ b/src/ui/Views/Organisation/About.cshtml
@@ -12,7 +12,7 @@
 <a href="@Url.Action("Courses", "Organisation", new {ucasCode = @Model.TabViewModel.UcasCode})" class="govuk-back-link">Back</a>
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
-  @Html.Partial("~/Views/Shared/_Alerts.cshtml")
+  @await Html.PartialAsync("~/Views/Shared/_Alerts.cshtml")
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/src/ui/Views/Organisation/About.cshtml
+++ b/src/ui/Views/Organisation/About.cshtml
@@ -9,194 +9,200 @@
   var workflowStatus = Model.GetWorkflowStatus();
 }
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="course-basicinfo govuk-!-margin-bottom-9">
-      <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl">@Model.TabViewModel.OrganisationName</span>
-        About your organisation
-      </h1>
+<a href="@Url.Action("Courses", "Organisation", new {ucasCode = @Model.TabViewModel.UcasCode})" class="govuk-back-link">Back</a>
+
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  @Html.Partial("~/Views/Shared/_Alerts.cshtml")
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="course-basicinfo govuk-!-margin-bottom-9">
+        <h1 class="govuk-heading-xl">
+          <span class="govuk-caption-xl">@Model.TabViewModel.OrganisationName</span>
+          About your organisation
+        </h1>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <form asp-controller="Organisation" asp-action="About" method="post" data-module="form">
-      <input type="hidden" asp-for="@Model.PublishOrganisation" value="false"></input>
-      <input type="hidden" asp-for="@Model.InstitutionCode"></input>
-      @Html.Partial("Shared/ErrorSummary")
-      <p class="govuk-body">This is your chance to tell applicants why they should choose to train with you. You could describe any advantages and special
-      features of you as a training provider.</p>
-      <p class="govuk-body">You must be specific and factual with any claims you make, and support them with evidence. For example:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>don’t say “our students are some of the happiest in the country”</li>
-        <li> do say “the Times Educational Supplement ranked our students as 4th happiest in the country”</li>
-      </ul>
-      <div class="govuk-character-count" data-module="character-count" data-maxwords="250">
-        <div id="TrainWithUs-wrapper" class="govuk-form-group @(train_with_us ? "govuk-form-group--error" : " ")">
-          <label asp-for="TrainWithUs" class="govuk-label govuk-!-font-weight-bold">Training with you</label>
-          @if (train_with_us) {
-            <span asp-validation-for="TrainWithUs" class="govuk-error-message"></span>
-          }
-          <textarea asp-for="TrainWithUs" class="govuk-textarea js-character-count" rows="15" data-module="character-count"></textarea>
-        </div>
-      </div>
-
-      @if(Model.AboutTrainingProviders.Any()) {
-        <h2 class="govuk-heading-l">About your accredited provider</h2>
-        <p class="govuk-body">Describe any advantages and special features of your accredited provider. You must be specific and factual with any claims you make, and support them with evidence.</p>
-
-        @for (int i = 0; i < Model.AboutTrainingProviders.Count; i++) {
-            var aboutTrainingProviderKey = "AboutTrainingProviders_"+i+"__Description";
-            var hasErrored = ViewData.ModelState[aboutTrainingProviderKey] != null && ViewData.ModelState[aboutTrainingProviderKey].Errors.Any();
-          <div class="govuk-character-count" data-module="character-count" data-maxwords="100">
-              <div id="@aboutTrainingProviderKey-wrapper" class="govuk-form-group @(hasErrored ? "govuk-form-group--error" : " ")">
-                  <input type="hidden" asp-for="@Model.AboutTrainingProviders[i].InstitutionCode" />
-                  <input type="hidden" asp-for="@Model.AboutTrainingProviders[i].InstitutionName" />
-                  <label class="govuk-label govuk-!-font-weight-bold" asp-for="@Model.AboutTrainingProviders[i].Description">
-                      @Model.AboutTrainingProviders[i].InstitutionName (optional)
-                  </label>
-                  @if (hasErrored)
-                  {
-                      <span asp-validation-for="@Model.AboutTrainingProviders[i].Description" class="govuk-error-message">@Model.AboutTrainingProviders[i].ValidationMessage</span>
-                  }
-                  <textarea class="govuk-textarea js-character-count" rows="10" asp-for="@Model.AboutTrainingProviders[i].Description"></textarea>
-              </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form asp-controller="Organisation" asp-action="About" method="post" data-module="form">
+        <input type="hidden" asp-for="@Model.PublishOrganisation" value="false"></input>
+        <input type="hidden" asp-for="@Model.InstitutionCode"></input>
+        @Html.Partial("Shared/ErrorSummary")
+        <p class="govuk-body">This is your chance to tell applicants why they should choose to train with you. You could describe any advantages and special
+        features of you as a training provider.</p>
+        <p class="govuk-body">You must be specific and factual with any claims you make, and support them with evidence. For example:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>don’t say “our students are some of the happiest in the country”</li>
+          <li> do say “the Times Educational Supplement ranked our students as 4th happiest in the country”</li>
+        </ul>
+        <div class="govuk-character-count" data-module="character-count" data-maxwords="250">
+          <div id="TrainWithUs-wrapper" class="govuk-form-group @(train_with_us ? "govuk-form-group--error" : " ")">
+            <label asp-for="TrainWithUs" class="govuk-label govuk-!-font-weight-bold">Training with you</label>
+            @if (train_with_us) {
+              <span asp-validation-for="TrainWithUs" class="govuk-error-message"></span>
+            }
+            <textarea asp-for="TrainWithUs" class="govuk-textarea js-character-count" rows="15" data-module="character-count"></textarea>
           </div>
-        }
-      }
-
-      <h2 class="govuk-heading-l">Training with disabilities and other needs</h2>
-      <p class="govuk-body">Say how you support candidates with disabilities and other needs. This could include candidates with:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>dyslexia</li>
-        <li>physical, hearing and visual impairments</li>
-        <li>mental health conditions</li>
-      </ul>
-      <p class="govuk-body">If accessibility varies between locations, give details. It’s also useful for applicants to know how you’ve accommodated others with specific access needs in the past.</p>
-      <div class="govuk-character-count" data-module="character-count" data-maxwords="250">
-        <div id="TrainWithDisability-wrapper" class="govuk-form-group @(train_with_disability ? "govuk-form-group--error" : "")">
-          <label asp-for="TrainWithDisability" class="govuk-label govuk-!-font-weight-bold">Training with disabilities and other needs</label>
-          @if (train_with_disability) {
-            @Html.ValidationMessageFor(m => m.TrainWithDisability, "", new { @class="govuk-error-message" })
-          }
-          <textarea asp-for="TrainWithDisability" class="govuk-textarea js-character-count" rows="15"></textarea>
         </div>
-      </div>
-      <div class="form-group">
-        <input type="submit" class="govuk-button" value="Save" />
-      </div>
-      <div class="form-group">
-        <p class="govuk-body"><a href="@Url.Action("About", "Organisation")" class="govuk-link">Cancel changes</a></p>
-      </div>
-    </form>
+
+        @if(Model.AboutTrainingProviders.Any()) {
+          <h2 class="govuk-heading-l">About your accredited provider</h2>
+          <p class="govuk-body">Describe any advantages and special features of your accredited provider. You must be specific and factual with any claims you make, and support them with evidence.</p>
+
+          @for (int i = 0; i < Model.AboutTrainingProviders.Count; i++) {
+              var aboutTrainingProviderKey = "AboutTrainingProviders_"+i+"__Description";
+              var hasErrored = ViewData.ModelState[aboutTrainingProviderKey] != null && ViewData.ModelState[aboutTrainingProviderKey].Errors.Any();
+            <div class="govuk-character-count" data-module="character-count" data-maxwords="100">
+                <div id="@aboutTrainingProviderKey-wrapper" class="govuk-form-group @(hasErrored ? "govuk-form-group--error" : " ")">
+                    <input type="hidden" asp-for="@Model.AboutTrainingProviders[i].InstitutionCode" />
+                    <input type="hidden" asp-for="@Model.AboutTrainingProviders[i].InstitutionName" />
+                    <label class="govuk-label govuk-!-font-weight-bold" asp-for="@Model.AboutTrainingProviders[i].Description">
+                        @Model.AboutTrainingProviders[i].InstitutionName (optional)
+                    </label>
+                    @if (hasErrored)
+                    {
+                        <span asp-validation-for="@Model.AboutTrainingProviders[i].Description" class="govuk-error-message">@Model.AboutTrainingProviders[i].ValidationMessage</span>
+                    }
+                    <textarea class="govuk-textarea js-character-count" rows="10" asp-for="@Model.AboutTrainingProviders[i].Description"></textarea>
+                </div>
+            </div>
+          }
+        }
+
+        <h2 class="govuk-heading-l">Training with disabilities and other needs</h2>
+        <p class="govuk-body">Say how you support candidates with disabilities and other needs. This could include candidates with:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>dyslexia</li>
+          <li>physical, hearing and visual impairments</li>
+          <li>mental health conditions</li>
+        </ul>
+        <p class="govuk-body">If accessibility varies between locations, give details. It’s also useful for applicants to know how you’ve accommodated others with specific access needs in the past.</p>
+        <div class="govuk-character-count" data-module="character-count" data-maxwords="250">
+          <div id="TrainWithDisability-wrapper" class="govuk-form-group @(train_with_disability ? "govuk-form-group--error" : "")">
+            <label asp-for="TrainWithDisability" class="govuk-label govuk-!-font-weight-bold">Training with disabilities and other needs</label>
+            @if (train_with_disability) {
+              @Html.ValidationMessageFor(m => m.TrainWithDisability, "", new { @class="govuk-error-message" })
+            }
+            <textarea asp-for="TrainWithDisability" class="govuk-textarea js-character-count" rows="15"></textarea>
+          </div>
+        </div>
+        <div class="form-group">
+          <input type="submit" class="govuk-button" value="Save" />
+        </div>
+        <div class="form-group">
+          <p class="govuk-body"><a href="@Url.Action("About", "Organisation")" class="govuk-link">Cancel changes</a></p>
+        </div>
+      </form>
+    </div>
+    <div class="govuk-grid-column-one-third">
+
+      <aside class="related">
+        @switch(workflowStatus)
+        {
+          case WorkflowStatus.Blank :
+            <strong class="govuk-tag govuk-tag--blank">Empty</strong>
+            <p class="govuk-body">You need to complete and publish this information.</p>
+
+            @if (Model.AllowPreview)
+            {
+              <hr class="related__section-break" />
+              <h4 class="govuk-heading-m">Preview</h4>
+              <p class="govuk-body">This information will show on all your courses.</p>
+              <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+            }
+
+            <hr class="related__section-break">
+            <h4 class="govuk-heading-m">Publish</h4>
+            <p class="govuk-body">Applicants will see published information from October.</p>
+
+            <form asp-controller="Organisation" asp-action="about" method="post">
+              <input type="submit" class="govuk-button" value="Publish" />
+              <input type="hidden" asp-for="@Model.PublishOrganisation" value="true" />
+            </form>
+            break;
+          case WorkflowStatus.InitialDraft :
+            <strong class="govuk-tag govuk-tag--draft">Draft</strong>
+            <p class="govuk-body">You have unpublished changes.</p>
+
+            @if (Model.AllowPreview)
+            {
+              <hr class="related__section-break" />
+              <h4 class="govuk-heading-m">Preview</h4>
+              <p class="govuk-body">This information will show on all your courses.</p>
+              <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+            }
+
+            <hr class="related__section-break">
+            <h4 class="govuk-heading-m">Publish</h4>
+            <p class="govuk-body">Applicants will see published information from October.</p>
+
+            <form asp-controller="Organisation" asp-action="about" method="post">
+              <input type="submit" class="govuk-button" value="Publish" />
+              <input type="hidden" asp-for="@Model.PublishOrganisation" value="true" />
+            </form>
+            break;
+          case WorkflowStatus.Published :
+            <strong class="govuk-tag govuk-tag--published">Published</strong>
+            <p class="govuk-body">Applicants will see this on all your courses from October.</p>
+            <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
+
+            break;
+          case WorkflowStatus.SubsequentDraft :
+            <strong class="govuk-tag govuk-tag--draft">Draft</strong>
+            <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
+            <p class="govuk-body">You have unpublished changes.</p>
+
+            @if (Model.AllowPreview)
+            {
+              <hr class="related__section-break" />
+              <h4 class="govuk-heading-m">Preview</h4>
+              <p class="govuk-body">This information will show on all your courses.</p>
+              <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+            }
+
+            <hr class="related__section-break">
+            <h4 class="govuk-heading-m">Publish</h4>
+            <p class="govuk-body">Applicants will see published information from October.</p>
+
+            <form asp-controller="Organisation" asp-action="about" method="post">
+              <input type="hidden" asp-for="@Model.PublishOrganisation" value="true" />
+              <input type="submit" class="govuk-button" value="Publish" />
+            </form>
+            break;
+          case WorkflowStatus.BlankSubsequentDraft :
+            <strong class="govuk-tag govuk-tag--draft">Empty</strong>
+            <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
+            <p class="govuk-body">You have unpublished changes.</p>
+
+            @if (Model.AllowPreview)
+            {
+              <hr class="related__section-break" />
+              <h4 class="govuk-heading-m">Preview</h4>
+              <p class="govuk-body">This information will show on all your courses.</p>
+              <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
+            }
+
+            <hr class="related__section-break">
+            <h4 class="govuk-heading-m">Publish</h4>
+            <p class="govuk-body">Applicants will see published information from October.</p>
+
+            <form asp-controller="Organisation" asp-action="about" method="post">
+              <input type="hidden" asp-for="@Model.PublishOrganisation" value="true" />
+              <input type="submit" class="govuk-button" value="Publish" />
+            </form>
+            break;
+          default:
+            break;
+        }
+
+        <hr class="related__section-break">
+
+        @Html.Partial("FormattingAdvice")
+      </aside>
+
+    </div>
   </div>
-  <div class="govuk-grid-column-one-third">
-
-    <aside class="related">
-      @switch(workflowStatus)
-      {
-        case WorkflowStatus.Blank :
-          <strong class="govuk-tag govuk-tag--blank">Empty</strong>
-          <p class="govuk-body">You need to complete and publish this information.</p>
-
-          @if (Model.AllowPreview)
-          {
-            <hr class="related__section-break" />
-            <h4 class="govuk-heading-m">Preview</h4>
-            <p class="govuk-body">This information will show on all your courses.</p>
-            <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
-          }
-
-          <hr class="related__section-break">
-          <h4 class="govuk-heading-m">Publish</h4>
-          <p class="govuk-body">Applicants will see published information from October.</p>
-
-          <form asp-controller="Organisation" asp-action="about" method="post">
-            <input type="submit" class="govuk-button" value="Publish" />
-            <input type="hidden" asp-for="@Model.PublishOrganisation" value="true" />
-          </form>
-          break;
-        case WorkflowStatus.InitialDraft :
-          <strong class="govuk-tag govuk-tag--draft">Draft</strong>
-          <p class="govuk-body">You have unpublished changes.</p>
-
-          @if (Model.AllowPreview)
-          {
-            <hr class="related__section-break" />
-            <h4 class="govuk-heading-m">Preview</h4>
-            <p class="govuk-body">This information will show on all your courses.</p>
-            <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
-          }
-
-          <hr class="related__section-break">
-          <h4 class="govuk-heading-m">Publish</h4>
-          <p class="govuk-body">Applicants will see published information from October.</p>
-
-          <form asp-controller="Organisation" asp-action="about" method="post">
-            <input type="submit" class="govuk-button" value="Publish" />
-            <input type="hidden" asp-for="@Model.PublishOrganisation" value="true" />
-          </form>
-          break;
-        case WorkflowStatus.Published :
-          <strong class="govuk-tag govuk-tag--published">Published</strong>
-          <p class="govuk-body">Applicants will see this on all your courses from October.</p>
-          <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
-
-          break;
-        case WorkflowStatus.SubsequentDraft :
-          <strong class="govuk-tag govuk-tag--draft">Draft</strong>
-          <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
-          <p class="govuk-body">You have unpublished changes.</p>
-
-          @if (Model.AllowPreview)
-          {
-            <hr class="related__section-break" />
-            <h4 class="govuk-heading-m">Preview</h4>
-            <p class="govuk-body">This information will show on all your courses.</p>
-            <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
-          }
-
-          <hr class="related__section-break">
-          <h4 class="govuk-heading-m">Publish</h4>
-          <p class="govuk-body">Applicants will see published information from October.</p>
-
-          <form asp-controller="Organisation" asp-action="about" method="post">
-            <input type="hidden" asp-for="@Model.PublishOrganisation" value="true" />
-            <input type="submit" class="govuk-button" value="Publish" />
-          </form>
-          break;
-        case WorkflowStatus.BlankSubsequentDraft :
-          <strong class="govuk-tag govuk-tag--draft">Empty</strong>
-          <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
-          <p class="govuk-body">You have unpublished changes.</p>
-
-          @if (Model.AllowPreview)
-          {
-            <hr class="related__section-break" />
-            <h4 class="govuk-heading-m">Preview</h4>
-            <p class="govuk-body">This information will show on all your courses.</p>
-            <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
-          }
-
-          <hr class="related__section-break">
-          <h4 class="govuk-heading-m">Publish</h4>
-          <p class="govuk-body">Applicants will see published information from October.</p>
-
-          <form asp-controller="Organisation" asp-action="about" method="post">
-            <input type="hidden" asp-for="@Model.PublishOrganisation" value="true" />
-            <input type="submit" class="govuk-button" value="Publish" />
-          </form>
-          break;
-        default:
-          break;
-      }
-
-      <hr class="related__section-break">
-
-      @Html.Partial("FormattingAdvice")
-    </aside>
-
-  </div>
-</div>
+</main>

--- a/src/ui/Views/Organisation/Courses.cshtml
+++ b/src/ui/Views/Organisation/Courses.cshtml
@@ -5,72 +5,90 @@
   ViewBag.Title = Model.InstitutionName;
 }
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">@Model.TabViewModel.OrganisationName</h1>
-    <h2 class="govuk-heading-l">Step 1. About your organisation</h2>
-    <p class="govuk-body">You need to add a description of your organisation - this is a chance to tell applicants why they should train with you. You should also say what you do for candidates with disabilities and other needs, and check your contact details to make sure they're correct.</p>
-    <p class="govuk-body">Once you’ve published your organisation information, it will show on each of your course pages. You’ll have to add your course details separately in Step 2 below.</p>
-    <p class="govuk-body"><a class="govuk-link" href="@Url.Action("About", "Organisation")">Fill in your organisation information</a></p>
+@if (Model.TabViewModel.MultipleOrganisations) {
+  <nav class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a href="@Url.Action("index", "Organisations")" class="govuk-breadcrumbs__link">Organisations</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        @Model.TabViewModel.OrganisationName
+      </li>
+    </ol>
+  </nav>
+}
+
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  @Html.Partial("~/Views/Organisation/Shared/RequestAccessSuccess.cshtml")
+  @Html.Partial("~/Views/Shared/_Alerts.cshtml")
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">@Model.TabViewModel.OrganisationName</h1>
+      <h2 class="govuk-heading-l">Step 1. About your organisation</h2>
+      <p class="govuk-body">You need to add a description of your organisation - this is a chance to tell applicants why they should train with you. You should also say what you do for candidates with disabilities and other needs, and check your contact details to make sure they're correct.</p>
+      <p class="govuk-body">Once you’ve published your organisation information, it will show on each of your course pages. You’ll have to add your course details separately in Step 2 below.</p>
+      <p class="govuk-body"><a class="govuk-link" href="@Url.Action("About", "Organisation")">Fill in your organisation information</a></p>
+    </div>
   </div>
-</div>
 
-<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+  <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Step 2. Course details</h2>
-    <h3 class="govuk-heading-m">Preview and publish courses</h3>
-    <p class="govuk-body">Give more details about each of your courses - including their structure and content, information about fees and financial help, and the qualifications needed for them.</p>
-    <p class="govuk-body">Make sure you preview each course before you publish it, to see how it will look online to applicants. Your courses won’t be seen by applicants until the search service, Find postgraduate teacher training, is launched in October.</p>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-l">Step 2. Course details</h2>
+      <h3 class="govuk-heading-m">Preview and publish courses</h3>
+      <p class="govuk-body">Give more details about each of your courses - including their structure and content, information about fees and financial help, and the qualifications needed for them.</p>
+      <p class="govuk-body">Make sure you preview each course before you publish it, to see how it will look online to applicants. Your courses won’t be seen by applicants until the search service, Find postgraduate teacher training, is launched in October.</p>
+    </div>
   </div>
-</div>
 
-<hr class="govuk-section-break govuk-section-break--m">
+  <hr class="govuk-section-break govuk-section-break--m">
 
-  @foreach (var provider in Model.Providers)
-  {
-    if (!string.IsNullOrWhiteSpace(provider.ProviderId))
+    @foreach (var provider in Model.Providers)
     {
-      <h3 class="govuk-heading-m">
-        <span class="govuk-caption-m">Accredited provider</span>
-        @provider.ProviderName
-      </h3>
-    }
-
-    <table class="ucas-info-table govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header ucas-info-table__code-col" scope="col">Code</th>
-          <th class="govuk-table__header ucas-info-table__subject-col" scope="col">Subject</th>
-          <th class="govuk-table__header ucas-info-table__type-col" scope="col">Type</th>
-          <th class="govuk-table__header ucas-info-table__type-col" scope="col">Status</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-      @foreach (var course in provider.Courses)
+      if (!string.IsNullOrWhiteSpace(provider.ProviderId))
       {
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">@course.CourseCode</td>
-
-          <td class="govuk-table__cell">
-            <a href="@Url.Action("variants", "course", new {instCode = Model.InstitutionId, accreditingProviderId = course.AccreditingProviderId, ucasCode = course.CourseCode})" class="govuk-link">@course.Name</a>
-          </td>
-          <td class="govuk-table__cell">@course.GetCourseVariantType()</td>
-          <td class="govuk-table__cell">@course.GetCourseStatus()</td>
-        </tr>
+        <h3 class="govuk-heading-m">
+          <span class="govuk-caption-m">Accredited provider</span>
+          @provider.ProviderName
+        </h3>
       }
-      </tbody>
-    </table>
-  }
-</section>
 
-<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+      <table class="ucas-info-table govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header ucas-info-table__code-col" scope="col">Code</th>
+            <th class="govuk-table__header ucas-info-table__subject-col" scope="col">Subject</th>
+            <th class="govuk-table__header ucas-info-table__type-col" scope="col">Type</th>
+            <th class="govuk-table__header ucas-info-table__type-col" scope="col">Status</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        @foreach (var course in provider.Courses)
+        {
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">@course.CourseCode</td>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Request access for someone else</h2>
-    <p class="govuk-body">You can request a DfE Sign-in account for others who manage your courses.</p>
-    <p class="govuk-body"><a class="govuk-link" href="@Url.Action("RequestAccess", "Organisation")">Request access for someone else</a></p>
+            <td class="govuk-table__cell">
+              <a href="@Url.Action("variants", "course", new {instCode = Model.InstitutionId, accreditingProviderId = course.AccreditingProviderId, ucasCode = course.CourseCode})" class="govuk-link">@course.Name</a>
+            </td>
+            <td class="govuk-table__cell">@course.GetCourseVariantType()</td>
+            <td class="govuk-table__cell">@course.GetCourseStatus()</td>
+          </tr>
+        }
+        </tbody>
+      </table>
+    }
+  </section>
+
+  <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-l">Request access for someone else</h2>
+      <p class="govuk-body">You can request a DfE Sign-in account for others who manage your courses.</p>
+      <p class="govuk-body"><a class="govuk-link" href="@Url.Action("RequestAccess", "Organisation")">Request access for someone else</a></p>
+    </div>
   </div>
-</div>
+</main>

--- a/src/ui/Views/Organisation/Courses.cshtml
+++ b/src/ui/Views/Organisation/Courses.cshtml
@@ -20,7 +20,7 @@
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
   @Html.Partial("~/Views/Organisation/Shared/RequestAccessSuccess.cshtml")
-  @Html.Partial("~/Views/Shared/_Alerts.cshtml")
+  @await Html.PartialAsync("~/Views/Shared/_Alerts.cshtml")
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/src/ui/Views/Organisation/RequestAccess.cshtml
+++ b/src/ui/Views/Organisation/RequestAccess.cshtml
@@ -11,7 +11,7 @@
 <a href="@Url.Action("Courses", "Organisation", new {ucasCode = @Model.TabViewModel.UcasCode})" class="govuk-back-link">Back</a>
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
-  @Html.Partial("~/Views/Shared/_Alerts.cshtml")
+  @await Html.PartialAsync("~/Views/Shared/_Alerts.cshtml")
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/src/ui/Views/Organisation/RequestAccess.cshtml
+++ b/src/ui/Views/Organisation/RequestAccess.cshtml
@@ -8,53 +8,59 @@
   var rv = ViewData.ModelState["Reason"] != null && ViewData.ModelState["Reason"].Errors.Any();
 }
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="course-basicinfo govuk-!-margin-bottom-9">
-      <h1 class="govuk-heading-xl">Request access for &nbsp; someone else</h1>
-      <p class="govuk-body">You can request a DfE Sign-in account for others who manage your courses.</p>
+<a href="@Url.Action("Courses", "Organisation", new {ucasCode = @Model.TabViewModel.UcasCode})" class="govuk-back-link">Back</a>
+
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  @Html.Partial("~/Views/Shared/_Alerts.cshtml")
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="course-basicinfo govuk-!-margin-bottom-9">
+        <h1 class="govuk-heading-xl">Request access for &nbsp; someone else</h1>
+        <p class="govuk-body">You can request a DfE Sign-in account for others who manage your courses.</p>
+      </div>
+      <h2 class="govuk-heading-m">Request an account for:</h2>
+      <form asp-controller="Organisation" asp-action="RequestAccess" method="post">
+        @Html.Partial("ErrorSummary")
+        <div id="FirstName-wrapper" class="govuk-form-group @(fnv ? "govuk-form-group--error" : "")">
+          <label asp-for="FirstName" class="govuk-label">First name</label>
+          @if (fnv) {
+            <span asp-validation-for="FirstName" class="govuk-error-message"></span>
+          }
+          <input asp-for="FirstName" class="govuk-input govuk-!-width-one-half" />
+        </div>
+        <div id="LastName-wrapper" class="govuk-form-group @(lnv ? "govuk-form-group--error" : "")">
+          <label asp-for="LastName" class="govuk-label">Last name</label>
+          @if (lnv) {
+            <span asp-validation-for="LastName" class="govuk-error-message"></span>
+          }
+          <input asp-for="LastName" class="govuk-input govuk-!-width-one-half" />
+        </div>
+        <div id="EmailAddress-wrapper" class="govuk-form-group @(eav ? " govuk-form-group--error " : " ")">
+          <label asp-for="EmailAddress" class="govuk-label">Email address</label>
+          @if (eav) {
+            <span asp-validation-for="EmailAddress" class="govuk-error-message"></span>
+          }
+          <input asp-for="EmailAddress" class="govuk-input govuk-!-width-one-half" />
+        </div>
+        <div id="Organisation-wrapper" class="govuk-form-group @(ov ? "govuk-form-group--error" : "")">
+          <label asp-for="Organisation" class="govuk-label">Their organisation</label>
+          @if (ov) {
+            <span asp-validation-for="Organisation" class="govuk-error-message"></span>
+          }
+          <input asp-for="Organisation" class="govuk-input govuk-!-width-one-half" />
+        </div>
+        <div id="Reason-wrapper" class="govuk-form-group @(rv ? "govuk-form-group--error" : "")">
+          <label asp-for="Reason" class="govuk-label">Reason they need access</label>
+          @if (rv) {
+            <span asp-validation-for="Reason" class="govuk-error-message"></span>
+          }
+          <textarea asp-for="Reason" class="govuk-textarea govuk-!-width-two-thirds"></textarea>
+        </div>
+        <div class="form-group">
+          <input type="submit" class="govuk-button" value="Request access" />
+        </div>
+      </form>
     </div>
-    <h2 class="govuk-heading-m">Request an account for:</h2>
-    <form asp-controller="Organisation" asp-action="RequestAccess" method="post">
-      @Html.Partial("ErrorSummary")
-      <div id="FirstName-wrapper" class="govuk-form-group @(fnv ? "govuk-form-group--error" : "")">
-        <label asp-for="FirstName" class="govuk-label">First name</label>
-        @if (fnv) {
-          <span asp-validation-for="FirstName" class="govuk-error-message"></span>
-        }
-        <input asp-for="FirstName" class="govuk-input govuk-!-width-one-half" />
-      </div>
-      <div id="LastName-wrapper" class="govuk-form-group @(lnv ? "govuk-form-group--error" : "")">
-        <label asp-for="LastName" class="govuk-label">Last name</label>
-        @if (lnv) {
-          <span asp-validation-for="LastName" class="govuk-error-message"></span>
-        }
-        <input asp-for="LastName" class="govuk-input govuk-!-width-one-half" />
-      </div>
-      <div id="EmailAddress-wrapper" class="govuk-form-group @(eav ? " govuk-form-group--error " : " ")">
-        <label asp-for="EmailAddress" class="govuk-label">Email address</label>
-        @if (eav) {
-          <span asp-validation-for="EmailAddress" class="govuk-error-message"></span>
-        }
-        <input asp-for="EmailAddress" class="govuk-input govuk-!-width-one-half" />
-      </div>
-      <div id="Organisation-wrapper" class="govuk-form-group @(ov ? "govuk-form-group--error" : "")">
-        <label asp-for="Organisation" class="govuk-label">Their organisation</label>
-        @if (ov) {
-          <span asp-validation-for="Organisation" class="govuk-error-message"></span>
-        }
-        <input asp-for="Organisation" class="govuk-input govuk-!-width-one-half" />
-      </div>
-      <div id="Reason-wrapper" class="govuk-form-group @(rv ? "govuk-form-group--error" : "")">
-        <label asp-for="Reason" class="govuk-label">Reason they need access</label>
-        @if (rv) {
-          <span asp-validation-for="Reason" class="govuk-error-message"></span>
-        }
-        <textarea asp-for="Reason" class="govuk-textarea govuk-!-width-two-thirds"></textarea>
-      </div>
-      <div class="form-group">
-        <input type="submit" class="govuk-button" value="Request access" />
-      </div>
-    </form>
   </div>
-</div>
+</main>

--- a/src/ui/Views/Organisation/Shared/_OrganisationDetailsViewLayout.cshtml
+++ b/src/ui/Views/Organisation/Shared/_OrganisationDetailsViewLayout.cshtml
@@ -5,10 +5,4 @@
   var viewModel = Model.TabViewModel;
 }
 
-<a href="@Url.Action("Courses", "Organisation", new {ucasCode = viewModel.UcasCode})" class="govuk-back-link">Back</a>
-
-<main role="main" class="govuk-main-wrapper" id="main-content">
-  @Html.Partial("~/Views/Organisation/Shared/RequestAccessSuccess.cshtml")
-  @Html.Partial("~/Views/Shared/_Alerts.cshtml")
-  @RenderBody()
-</main>
+@RenderBody()


### PR DESCRIPTION
### Context
User should be able to get back to thier org from about, courses or request access

### Changes proposed in this pull request
- Add correct back link from org child pages
- Add breadcrumb back to org page is user has multiple orgs

### Guidance to review
Before viewed if you ignore whitespace i.e. https://github.com/DFE-Digital/manage-courses-ui/pull/159/files?utf8=%E2%9C%93&diff=unified&w=1

# Single org access
<img width="885" alt="screen shot 2018-09-03 at 17 16 14" src="https://user-images.githubusercontent.com/3071606/44995900-13b2a080-af9d-11e8-8680-5c8d402bdf99.png">
<img width="885" alt="screen shot 2018-09-03 at 17 16 10" src="https://user-images.githubusercontent.com/3071606/44995901-13b2a080-af9d-11e8-93b2-ddbb41fac468.png">

# Access to multiple orgs
<img width="885" alt="screen shot 2018-09-03 at 17 13 44" src="https://user-images.githubusercontent.com/3071606/44995823-bdddf880-af9c-11e8-93fa-1c3d43269a82.png">
<img width="885" alt="screen shot 2018-09-03 at 17 14 56" src="https://user-images.githubusercontent.com/3071606/44995861-e4039880-af9c-11e8-81ae-e901226904cd.png">