### PR TITLE
Fix single org path

### DIFF
--- a/src/ui/Controllers/HomeController.cs
+++ b/src/ui/Controllers/HomeController.cs
@@ -43,7 +43,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
             var userOrganisations = orgs.ToList();
             if (userOrganisations.Count() == 1)
             {
-                return this.RedirectToAction("Courses", "Organisation", new { ucasCode = userOrganisations[0].UcasCode });
+                return this.RedirectToAction("Show", "Organisation", new { ucasCode = userOrganisations[0].UcasCode });
             }
 
             if (userOrganisations.Count() > 1)

--- a/src/ui/Controllers/RedirectController.cs
+++ b/src/ui/Controllers/RedirectController.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
   public class RedirectController : CommonAttributesControllerBase
   {
     [Authorize]
-    [Route("organisations/{ucasCode}/courses")]
+    [Route("organisation/{ucasCode}/courses")]
     public async Task<IActionResult> LegacyCoursePage(string ucasCode)
     {
       return RedirectToAction("Show", "Organisation", new { ucasCode });


### PR DESCRIPTION
### Context
- Redirect introduced (https://github.com/DFE-Digital/manage-courses-ui/pull/161) was wrong
- Single org entry point

### Changes proposed in this pull request
- Fix redirect
- If user only has one org we should redirect straight to the `org#show`

### Guidance to review
Login in as tim5 and tim4 to check multi org and single org
