### PR TITLE
make temp data more resilient

### DIFF
--- a/ManageCoursesUi.Tests/CourseControllerTests.cs
+++ b/ManageCoursesUi.Tests/CourseControllerTests.cs
@@ -386,13 +386,13 @@ namespace ManageCoursesUi.Tests
 
             var tempData = controller.TempData;
 
-            tempDataMock.Verify(x => x.Add("MessageType", "success"), Times.Once);
-            tempDataMock.Verify(x => x.Add("MessageTitle", "Your changes have been saved"), Times.Once);
-            tempDataMock.Verify(x => x.Add("MessageBodyHtml", $@"
+            tempDataMock.VerifySet(x => x["MessageType"] = "success", Times.Once);
+            tempDataMock.VerifySet(x => x["MessageTitle"] = "Your changes have been saved", Times.Once);
+            tempDataMock.VerifySet(x => x["MessageBodyHtml"] = $@"
                     <p class=""govuk-body"">
                         <a href='{previewLink}'>Preview your course</a>
                         to check for mistakes before publishing.
-                    </p>"), Times.Once);
+                    </p>", Times.Once);
 
             var routeValues = redirectToActionResult.RouteValues;
 
@@ -503,13 +503,13 @@ namespace ManageCoursesUi.Tests
 
             var tempData = controller.TempData;
 
-            tempDataMock.Verify(x => x.Add("MessageType", "success"), Times.Once);
-            tempDataMock.Verify(x => x.Add("MessageTitle", "Your changes have been saved"), Times.Once);
-            tempDataMock.Verify(x => x.Add("MessageBodyHtml", $@"
+            tempDataMock.VerifySet(x => x["MessageType"] = "success", Times.Once);
+            tempDataMock.VerifySet(x => x["MessageTitle"] = "Your changes have been saved", Times.Once);
+            tempDataMock.VerifySet(x => x["MessageBodyHtml"] = $@"
                     <p class=""govuk-body"">
                         <a href='{previewLink}'>Preview your course</a>
                         to check for mistakes before publishing.
-                    </p>"), Times.Once);
+                    </p>", Times.Once);
 
             var routeValues = redirectToActionResult.RouteValues;
 
@@ -622,13 +622,13 @@ namespace ManageCoursesUi.Tests
 
             var tempData = controller.TempData;
 
-            tempDataMock.Verify(x => x.Add("MessageType", "success"), Times.Once);
-            tempDataMock.Verify(x => x.Add("MessageTitle", "Your changes have been saved"), Times.Once);
-            tempDataMock.Verify(x => x.Add("MessageBodyHtml", $@"
+            tempDataMock.VerifySet(x => x["MessageType"] = "success", Times.Once);
+            tempDataMock.VerifySet(x => x["MessageTitle"] = "Your changes have been saved", Times.Once);
+            tempDataMock.VerifySet(x => x["MessageBodyHtml"] = $@"
                     <p class=""govuk-body"">
                         <a href='{previewLink}'>Preview your course</a>
                         to check for mistakes before publishing.
-                    </p>"), Times.Once);
+                    </p>", Times.Once);
 
             var routeValues = redirectToActionResult.RouteValues;
 
@@ -747,13 +747,15 @@ namespace ManageCoursesUi.Tests
 
             var tempData = controller.TempData;
 
-            tempDataMock.Verify(x => x.Add("MessageType", "success"), Times.Once);
-            tempDataMock.Verify(x => x.Add("MessageTitle", "Your changes have been saved"), Times.Once);
-            tempDataMock.Verify(x => x.Add("MessageBodyHtml", $@"
+
+            tempDataMock.VerifySet(x => x["MessageType"] = "success", Times.Once);
+            tempDataMock.VerifySet(x => x["MessageType"] = "success", Times.Once);
+            tempDataMock.VerifySet(x => x["MessageTitle"] = "Your changes have been saved", Times.Once);
+            tempDataMock.VerifySet(x => x["MessageBodyHtml"] = $@"
                     <p class=""govuk-body"">
                         <a href='{previewLink}'>Preview your course</a>
                         to check for mistakes before publishing.
-                    </p>"), Times.Once);
+                    </p>", Times.Once);
 
             var routeValues = redirectToActionResult.RouteValues;
 

--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -82,17 +82,17 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
 
             if (result)
             {
-                TempData.Add("MessageType", "success");
-                TempData.Add("MessageTitle", "Your course has been published");
+                TempData["MessageType"] = "success";
+                TempData["MessageTitle"] = "Your course has been published";
                 var searchUrl = searchAndCompareUrlService.GetCoursePageUri(course.InstCode, course.CourseCode);
                 if (featureFlags.ShowCourseLiveView)
                 {
-                    TempData.Add("MessageBodyHtml", $@"
+                    TempData["MessageBodyHtml"] = $@"
                         <p class=""govuk-body"">
                             See how this course looks to applicants:
                             <br />
                             <a href='{searchUrl}'>View on website</a>
-                        </p>");
+                        </p>";
                 }
             }
 
@@ -380,16 +380,16 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
 
         private void CourseSavedMessage()
         {
-            TempData.Add("MessageType", "success");
-            TempData.Add("MessageTitle", "Your changes have been saved");
+            TempData["MessageType"] = "success";
+            TempData["MessageTitle"] = "Your changes have been saved";
             if (featureFlags.ShowCoursePreview)
             {
                 var previewLink = Url.Action("Preview");
-                TempData.Add("MessageBodyHtml", $@"
+                TempData["MessageBodyHtml"] = $@"
                     <p class=""govuk-body"">
                         <a href='{previewLink}'>Preview your course</a>
                         to check for mistakes before publishing.
-                    </p>");
+                    </p>";
             }
         }
 


### PR DESCRIPTION
### Context

If a post that creates a success message gets interrupted, stale message info remains in `TempData` causing a throw next time we want to render a message in this way.

### Changes proposed in this pull request

Use `[]` syntax instead. This way, it doesn't matter if TempData already contains stale data - it just gets overwritten
