### PR TITLE
Make the "Not running" box less prominent

### DIFF
--- a/src/ui/Assets/Styles/site.scss
+++ b/src/ui/Assets/Styles/site.scss
@@ -79,7 +79,7 @@ $govuk-global-styles: true;
   }
 }
 
-.govuk-warning-text {
+.govuk-warning-text--inline {
   margin-bottom: 0;
 
   + .govuk-body {

--- a/src/ui/Assets/Styles/site.scss
+++ b/src/ui/Assets/Styles/site.scss
@@ -78,3 +78,12 @@ $govuk-global-styles: true;
     }
   }
 }
+
+.govuk-warning-text {
+  margin-bottom: 0;
+
+  + .govuk-body {
+    padding-left: govuk-spacing(8);
+    margin-bottom: govuk-spacing(6);
+  }
+}

--- a/src/ui/Views/Course/Variants.cshtml
+++ b/src/ui/Views/Course/Variants.cshtml
@@ -28,7 +28,7 @@
 
           @if(Model.Course.StatusAsEnum != CourseVariantStatus.Running)
           {
-            <div class="govuk-warning-text">
+            <div class="govuk-warning-text govuk-warning-text--inline">
               <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
               <strong class="govuk-warning-text__text">
                 @if(Model.Course.StatusAsEnum == CourseVariantStatus.New)

--- a/src/ui/Views/Course/Variants.cshtml
+++ b/src/ui/Views/Course/Variants.cshtml
@@ -20,39 +20,38 @@
     @Model.Course.Name (@Model.Course.ProgrammeCode)
   </h1>
 
-  @if(Model.Course.StatusAsEnum != CourseVariantStatus.Running)
-  {
-    <div class="govuk-notice-summary" role="alert">
-      <h3 class="govuk-notice-summary__title">
-        @if(Model.Course.StatusAsEnum == CourseVariantStatus.New)
-        {
-          <text>This course is new and not yet running.</text>
-        }
-        else
-        {
-          <text>This course is not running.</text>
-        }
-      </h3>
-      <div class="govuk-notice-summary__body">
-        <p class="govuk-body">
-          @if(Model.Course.StatusAsEnum == CourseVariantStatus.New)
-          {
-            <text>It won&#8217;t appear online until one or more training locations are set to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/netupdate2/Welcome.htm'>UCAS web-link</a>.</text>
-          }
-          else
-          {
-            <text>It won&#8217;t appear online. You can publish it by changing the status of one or more training locations to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/netupdate2/Welcome.htm'>UCAS web-link</a>.</text>
-          }
-        </p>
-      </div>
-    </div>
-  }
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="course-parts">
         <div class="course-parts__item">
           <h3 class="course-parts__title">Information from UCAS</h3>
+
+          @if(Model.Course.StatusAsEnum != CourseVariantStatus.Running)
+          {
+            <div class="govuk-warning-text">
+              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+              <strong class="govuk-warning-text__text">
+                @if(Model.Course.StatusAsEnum == CourseVariantStatus.New)
+                {
+                  <text>This course is new and not yet running.</text>
+                }
+                else
+                {
+                  <text>This course is not running.</text>
+                }
+              </strong>
+            </div>
+            <p class="govuk-body">
+              @if(Model.Course.StatusAsEnum == CourseVariantStatus.New)
+              {
+                <text>It won&#8217;t appear online until one or more training locations are set to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/netupdate2/Welcome.htm'>UCAS web-link</a>.</text>
+              }
+              else
+              {
+                <text>It won&#8217;t appear online. You can publish it by changing the status of one or more training locations to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/netupdate2/Welcome.htm'>UCAS web-link</a>.</text>
+              }
+            </p>
+          }
 
           <p class="govuk-body">You can only change this information using <a href="https://update.ucas.co.uk/netupdate2/Welcome.htm">UCAS web-link</a>. Changes will usually appear here within one working day.</p>
 

--- a/src/ui/Views/Course/Variants.cshtml
+++ b/src/ui/Views/Course/Variants.cshtml
@@ -20,29 +20,15 @@
     @Model.Course.Name (@Model.Course.ProgrammeCode)
   </h1>
 
-  @if(Model.Course.StatusAsEnum != CourseVariantStatus.Running)
+  @if(Model.Course.StatusAsEnum == CourseVariantStatus.NotRunning)
   {
     <div class="govuk-notice-summary" role="alert">
       <h3 class="govuk-notice-summary__title">
-        @if(Model.Course.StatusAsEnum == CourseVariantStatus.New)
-        {
-          <text>This course is new and not yet running.</text>
-        }
-        else
-        {
-          <text>This course is not running.</text>
-        }
+        This course is not running.
       </h3>
       <div class="govuk-notice-summary__body">
         <p class="govuk-body">
-          @if(Model.Course.StatusAsEnum == CourseVariantStatus.New)
-          {
-            <text>It won&#8217;t appear online until one or more training locations are set to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/netupdate2/Welcome.htm'>UCAS web-link</a>.</text>
-          }
-          else
-          {
-            <text>It won&#8217;t appear online. You can publish it by changing the status of one or more training locations to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/netupdate2/Welcome.htm'>UCAS web-link</a>.</text>
-          }
+          It won&#8217;t appear online. You can publish it by changing the status of one or more training locations to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/netupdate2/Welcome.htm'>UCAS web-link</a>.
         </p>
       </div>
     </div>
@@ -51,6 +37,13 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="course-parts">
+        @if(Model.Course.StatusAsEnum == CourseVariantStatus.New)
+        {
+          <div class="course-parts__item">
+            <h3 class="course-parts__title">This course is new and not yet running.</h3>
+            <p class="govuk-body">It won&#8217;t appear online until one or more training locations are set to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/netupdate2/Welcome.htm'>UCAS web-link</a>.</p>
+          </div>
+        }
         <div class="course-parts__item">
           <h3 class="course-parts__title">Information from UCAS</h3>
 

--- a/src/ui/Views/Course/Variants.cshtml
+++ b/src/ui/Views/Course/Variants.cshtml
@@ -20,15 +20,29 @@
     @Model.Course.Name (@Model.Course.ProgrammeCode)
   </h1>
 
-  @if(Model.Course.StatusAsEnum == CourseVariantStatus.NotRunning)
+  @if(Model.Course.StatusAsEnum != CourseVariantStatus.Running)
   {
     <div class="govuk-notice-summary" role="alert">
       <h3 class="govuk-notice-summary__title">
-        This course is not running.
+        @if(Model.Course.StatusAsEnum == CourseVariantStatus.New)
+        {
+          <text>This course is new and not yet running.</text>
+        }
+        else
+        {
+          <text>This course is not running.</text>
+        }
       </h3>
       <div class="govuk-notice-summary__body">
         <p class="govuk-body">
-          It won&#8217;t appear online. You can publish it by changing the status of one or more training locations to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/netupdate2/Welcome.htm'>UCAS web-link</a>.
+          @if(Model.Course.StatusAsEnum == CourseVariantStatus.New)
+          {
+            <text>It won&#8217;t appear online until one or more training locations are set to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/netupdate2/Welcome.htm'>UCAS web-link</a>.</text>
+          }
+          else
+          {
+            <text>It won&#8217;t appear online. You can publish it by changing the status of one or more training locations to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/netupdate2/Welcome.htm'>UCAS web-link</a>.</text>
+          }
         </p>
       </div>
     </div>
@@ -37,13 +51,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="course-parts">
-        @if(Model.Course.StatusAsEnum == CourseVariantStatus.New)
-        {
-          <div class="course-parts__item">
-            <h3 class="course-parts__title">This course is new and not yet running.</h3>
-            <p class="govuk-body">It won&#8217;t appear online until one or more training locations are set to &ldquo;running&rdquo; in <a href='https://update.ucas.co.uk/netupdate2/Welcome.htm'>UCAS web-link</a>.</p>
-          </div>
-        }
         <div class="course-parts__item">
           <h3 class="course-parts__title">Information from UCAS</h3>
 


### PR DESCRIPTION
Now that new courses can be edited, the box doesn't need to be as loud. The status relates to details we get from UCAS so move it below the "Information from UCAS" heading.
