### PR TITLE
Ensure all error and warning summaries are focused on load

### DIFF
--- a/src/ui/Views/Course/Shared/ErrorSummary.cshtml
+++ b/src/ui/Views/Course/Shared/ErrorSummary.cshtml
@@ -4,7 +4,7 @@
 
 @if (!@ViewContext.ModelState.IsValid)
 {
-    <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
+    <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1" data-module="error-summary">
         <h2 class="govuk-heading-m govuk-error-summary__title" id="error-summary-heading">
             You&#8217;ll need to correct some information.
         </h2>

--- a/src/ui/Views/Course/Shared/ErrorSummaryCourseOverview.cshtml
+++ b/src/ui/Views/Course/Shared/ErrorSummaryCourseOverview.cshtml
@@ -5,7 +5,7 @@
 
 @if (!@ViewContext.ModelState.IsValid)
 {
-    <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
+    <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1" data-module="error-summary">
         <h2 class="govuk-heading-m govuk-error-summary__title" id="error-summary-heading">
             You&#8217;ll need to correct some information.
         </h2>

--- a/src/ui/Views/Organisation/Shared/ErrorSummary.cshtml
+++ b/src/ui/Views/Organisation/Shared/ErrorSummary.cshtml
@@ -40,7 +40,7 @@
 
 
 
-<div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
+<div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1" data-module="error-summary">
         <h2 class="govuk-heading-m govuk-error-summary__title" id="error-summary-heading">
             You&#8217;ll need to correct some information.
         </h2>

--- a/src/ui/Views/Shared/CopyCourseContentMessage.cshtml
+++ b/src/ui/Views/Shared/CopyCourseContentMessage.cshtml
@@ -5,8 +5,8 @@
 
 @if(copied != null && copied.Any())
 {
-  <div class="govuk-warning-summary" role="alert" aria-labelledby="success-summary-heading" data-module="copy-course-warning">
-    <h2 class="govuk-warning-summary__title" id="success-summary-heading">
+  <div class="govuk-warning-summary" aria-labelledby="warning-summary-heading" tabindex="-1" data-module="error-summary" data-module="copy-course-warning" role="alert">
+    <h2 class="govuk-warning-summary__title" id="warning-summary-heading">
       Your changes are not yet saved
     </h2>
     <div class="govuk-warning-summary__body">

--- a/src/ui/Views/Shared/ErrorSummary.cshtml
+++ b/src/ui/Views/Shared/ErrorSummary.cshtml
@@ -14,7 +14,7 @@
 
     }).Select(x => new { Key = x, Value = this.ViewContext.ModelState[x] });
 
-    <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
+    <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1" data-module="error-summary">
         <h2 class="govuk-heading-m govuk-error-summary__title" id="error-summary-heading">
             You&#8217;ll need to correct some information.
         </h2>

--- a/src/ui/Views/Shared/_Alerts.cshtml
+++ b/src/ui/Views/Shared/_Alerts.cshtml
@@ -6,8 +6,8 @@
 
 @if (type != null)
 {
-  <div class="govuk-@type-summary" role="alert">
-    <h3 class="govuk-@type-summary__title">@title</h3>
+  <div class="govuk-@type-summary" role="alert" aria-labelledby="@type-summary-heading" tabindex="-1" data-module="error-summary">
+    <h3 class="govuk-@type-summary__title" id="@type-summary-heading">@title</h3>
 
     @if (body != null)
     {


### PR DESCRIPTION
### Context
Fixes #153

### Changes proposed in this pull request
- Init `error-summary` JS module to set focus on page load
- Add `aria-labelledby` to all error summaries

### Guidance to review
<img width="1380" alt="screen shot 2018-09-04 at 22 36 15" src="https://user-images.githubusercontent.com/3071606/45059148-ef38f000-b092-11e8-8506-2370b4dc087b.png">
