### PR TITLE
use new api contract that returns proper status codes

### DIFF
--- a/src/ui/ActionFilters/McExceptionFilter.cs
+++ b/src/ui/ActionFilters/McExceptionFilter.cs
@@ -11,9 +11,10 @@ namespace GovUk.Education.ManageCourses.Ui.ActionFilters
         public void OnException(ExceptionContext context)
         {
             var swaggerException = context.Exception as SwaggerException;
-            if (swaggerException?.StatusCode == (int) HttpStatusCode.Unauthorized)
+            
+            if (swaggerException?.StatusCode >= 400 && swaggerException?.StatusCode <= 404)
             {
-                context.Result = new RedirectToActionResult("Index", "Error", new { statusCode = 401 });
+                context.Result = new RedirectToActionResult("Index", "Error", new { statusCode = swaggerException?.StatusCode });
                 context.ExceptionHandled = true;
             }
             else if (swaggerException?.StatusCode == (int) HttpStatusCode.UnavailableForLegalReasons)

--- a/src/ui/ManageCoursesUi.csproj
+++ b/src/ui/ManageCoursesUi.csproj
@@ -29,7 +29,7 @@
   <Import Condition="Exists('$(ProjectDir)dev-sc-shared.targets')" Project="$(ProjectDir)dev-sc-shared.targets" />
 
   <ItemGroup Condition="Exists('$(ProjectDir)dev-mc-api.targets')==false">
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.11.0-proper-status-codes" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.11.0" />
   </ItemGroup>
   <ItemGroup Condition="Exists('$(ProjectDir)dev-sc-shared.targets')==false">    
     <PackageReference Include="GovUk.Education.SearchAndCompare.Ui.Shared" Version="0.4.0.*" />

--- a/src/ui/ManageCoursesUi.csproj
+++ b/src/ui/ManageCoursesUi.csproj
@@ -29,7 +29,7 @@
   <Import Condition="Exists('$(ProjectDir)dev-sc-shared.targets')" Project="$(ProjectDir)dev-sc-shared.targets" />
 
   <ItemGroup Condition="Exists('$(ProjectDir)dev-mc-api.targets')==false">
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.10.0.*" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.11.0-proper-status-codes" />
   </ItemGroup>
   <ItemGroup Condition="Exists('$(ProjectDir)dev-sc-shared.targets')==false">    
     <PackageReference Include="GovUk.Education.SearchAndCompare.Ui.Shared" Version="0.4.0.*" />


### PR DESCRIPTION
### Context

https://trello.com/c/wS9AhCIi/233-publish-courses-url-with-invalid-institution-code-should-return-404

### Changes proposed in this pull request

A change in the API means that it now gives more descriptive status codes

### Guidance to review

see corresponding api pr: https://github.com/DFE-Digital/manage-courses-api/pull/134