### PR TITLE
Highlight how to copy content

### DIFF
--- a/src/ui/Views/Organisation/Show.cshtml
+++ b/src/ui/Views/Organisation/Show.cshtml
@@ -39,6 +39,9 @@
       <h3 class="govuk-heading-m">Preview and publish courses</h3>
       <p class="govuk-body">Give more details about each of your courses - including their structure and content, information about fees and financial help, and the qualifications needed for them.</p>
       <p class="govuk-body">Make sure you preview each course before you publish it, to see how it will look online to applicants. Your courses won’t be seen by applicants until the search service, Find postgraduate teacher training, is launched in October.</p>
+
+      <h3 class="govuk-heading-m">Copying content between courses</h3>
+      <p class="govuk-body">After you’ve saved your first course, when you’re completing the next you can use the ‘copy from course’ feature to fill in fields. This can be found on the ‘About this course’, ‘Course length and fees’ and ‘Requirements and eligibility’ pages.</p>
     </div>
   </div>
 


### PR DESCRIPTION
### Context

People are missing the copy content feature.

### Changes proposed in this pull request

Put back the help text about copying between courses but also indicate which page this can be found on.

### Guidance to review

Make sure it looks ok, I can't run this locally.
