### PR TITLE
Fix copy course without saving error

### DIFF
--- a/src/ui/Assets/app.js
+++ b/src/ui/Assets/app.js
@@ -34,7 +34,7 @@ if ($form) {
   }
 }
 
-var $copyWarningMessage = document.querySelector('[data-module="copy-course-warning"]');
+var $copyWarningMessage = document.querySelector('[data-copy-course="warning"]');
 if ($copyWarningMessage) {
   window.onbeforeunload = function() {
     return 'You have unsaved changes, are you sure you want to leave?'

--- a/src/ui/Views/Shared/CopyCourseContentMessage.cshtml
+++ b/src/ui/Views/Shared/CopyCourseContentMessage.cshtml
@@ -5,7 +5,7 @@
 
 @if(copied != null && copied.Any())
 {
-  <div class="govuk-warning-summary" aria-labelledby="warning-summary-heading" tabindex="-1" data-module="error-summary" data-module="copy-course-warning" role="alert">
+  <div class="govuk-warning-summary" aria-labelledby="warning-summary-heading" tabindex="-1" data-module="error-summary" data-copy-course="warning" role="alert">
     <h2 class="govuk-warning-summary__title" id="warning-summary-heading">
       Your changes are not yet saved
     </h2>
@@ -27,7 +27,7 @@
 }
 else if (copied != null)
 {
-  <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
+  <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1" data-module="error-summary">
     <span class="govuk-body govuk-body-l govuk-!-font-weight-bold" id="error-summary-heading">
       There was no content to copy from course @copiedFrom?.Name (@copiedFrom?.ProgrammeCode)
     </span>


### PR DESCRIPTION
### Context
Fixes #195 

### Changes proposed in this pull request
Rename copy course data attribute used to fire function

### Guidance to review
Copy course content, then navigate away without saving, should get alert

![screen shot 2018-09-10 at 16 18 50](https://user-images.githubusercontent.com/3071606/45306785-5df3ce80-b515-11e8-9f81-17dc727b0a81.png)


