### PR TITLE
Make hr breaks visible on fees and salary pages

### DIFF
--- a/src/ui/Views/Course/Fees.cshtml
+++ b/src/ui/Views/Course/Fees.cshtml
@@ -68,7 +68,7 @@
               </div>
           </fieldset>
         </div>
-        <hr class="govuk-section-break govuk-section-break--l">
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
         <h2 class="govuk-heading-l">Course fees</h2>
         <div id="CourseFees-wrapper" class="govuk-form-group @(fee_uk_eu ? " govuk-form-group--error " : " ")">
           <label asp-for="FeeUkEu" class="govuk-label">Fee for UK and EU students</label>
@@ -94,7 +94,7 @@
             </div>
           </div>
         </div>
-         <h4 class="govuk-heading-m">Fee details</h4>
+        <h4 class="govuk-heading-m">Fee details</h4>
         <p class="govuk-body">If applicable, give further details about the fees for this course.</p>
         <p class="govuk-body">This could include:</p>
         <ul class="govuk-list govuk-list--bullet">
@@ -110,7 +110,7 @@
             <textarea asp-for="FeeDetails" class="govuk-textarea js-character-count" rows="15" data-module="character-count"></textarea>
           </div>
         </div>
-        <hr class="govuk-section-break govuk-section-break--l">
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
         <h2 class="govuk-heading-l">Financial support you offer</h2>
         <p class="govuk-body">If applicable, say more about the financial support you offer for this course. For example, any bursaries available.</p>
         <p class="govuk-body">You don’t need to add details of any DfE bursaries and subject scholarships here. These will be published automatically to your course page.</p>

--- a/src/ui/Views/Course/Salary.cshtml
+++ b/src/ui/Views/Course/Salary.cshtml
@@ -67,7 +67,7 @@
 
           </fieldset>
         </div>
-        <hr class="govuk-section-break govuk-section-break--l">
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
         <h2 class="govuk-heading-l">Salary</h2>
         <p class="govuk-body">Give details about the salary for this course.</p>
         <p class="govuk-body">You should:</p>


### PR DESCRIPTION
### Context

* Fee and salary pages were inconsistent

### Changes proposed in this pull request

* Updates the fees and salary pages to match other course pages
* More visible breaks between sections

### Guidance to review

* Check line breaks render ok on fees and salary pages
