### PR TITLE
Copy tweaks

### DIFF
--- a/src/ui/Views/Course/Salary.cshtml
+++ b/src/ui/Views/Course/Salary.cshtml
@@ -72,7 +72,7 @@
         <p class="govuk-body">Give details about the salary for this course.</p>
         <p class="govuk-body">You should:</p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>give an indication of the salary</li>
+          <li>give an indication of the salary – if you don't have the figure, say how it will be calculated (eg using the unqualified teachers’ pay scales)</li>
           <li>say whether there are any fees or others costs – if there are no fees for this course, you should also say so</li>
         </ul>
         <div class="govuk-character-count" data-module="character-count" data-maxwords="250">

--- a/src/ui/Views/Course/Salary.cshtml
+++ b/src/ui/Views/Course/Salary.cshtml
@@ -72,7 +72,7 @@
         <p class="govuk-body">Give details about the salary for this course.</p>
         <p class="govuk-body">You should:</p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>give an indication of the salary – if you don't have the figure, say how it will be calculated (eg using the unqualified teachers’ pay scales)</li>
+          <li>give an indication of the salary – if you don’t have the figure, say how it will be calculated (eg using the unqualified teachers’ pay scales)</li>
           <li>say whether there are any fees or others costs – if there are no fees for this course, you should also say so</li>
         </ul>
         <div class="govuk-character-count" data-module="character-count" data-maxwords="250">

--- a/src/ui/Views/Course/Show.cshtml
+++ b/src/ui/Views/Course/Show.cshtml
@@ -183,6 +183,7 @@
           <h4 class="govuk-heading-m">Publish</h4>
           <p class="govuk-body">Publish your changes.</p>
           <p class="govuk-body">Applicants will see published content from October.</p>
+          <p class="govuk-body">You can make changes to this course after publishing it.</p>
 
           <form asp-route="publish" method="post">
             <input type="submit" class="govuk-button" value="Publish" />

--- a/src/ui/Views/Organisation/About.cshtml
+++ b/src/ui/Views/Organisation/About.cshtml
@@ -113,6 +113,7 @@
             <hr class="related__section-break">
             <h4 class="govuk-heading-m">Publish</h4>
             <p class="govuk-body">Applicants will see published information from October.</p>
+            <p class="govuk-body">You can make changes to this after publishing it.</p>
 
             <form asp-controller="Organisation" asp-action="about" method="post">
               <input type="submit" class="govuk-button" value="Publish" />
@@ -131,6 +132,7 @@
             <hr class="related__section-break">
             <h4 class="govuk-heading-m">Publish</h4>
             <p class="govuk-body">Applicants will see published information from October.</p>
+            <p class="govuk-body">You can make changes to this after publishing it.</p>
 
             <form asp-controller="Organisation" asp-action="about" method="post">
               <input type="submit" class="govuk-button" value="Publish" />
@@ -156,6 +158,7 @@
             <hr class="related__section-break">
             <h4 class="govuk-heading-m">Publish</h4>
             <p class="govuk-body">Applicants will see published information from October.</p>
+            <p class="govuk-body">You can make changes to this after publishing it.</p>
 
             <form asp-controller="Organisation" asp-action="about" method="post">
               <input type="hidden" asp-for="@Model.PublishOrganisation" value="true" />
@@ -175,6 +178,7 @@
             <hr class="related__section-break">
             <h4 class="govuk-heading-m">Publish</h4>
             <p class="govuk-body">Applicants will see published information from October.</p>
+            <p class="govuk-body">You can make changes to this after publishing it.</p>
 
             <form asp-controller="Organisation" asp-action="about" method="post">
               <input type="hidden" asp-for="@Model.PublishOrganisation" value="true" />

--- a/src/ui/Views/Organisation/About.cshtml
+++ b/src/ui/Views/Organisation/About.cshtml
@@ -106,7 +106,7 @@
             <p class="govuk-body">You need to complete and publish this information.</p>
 
             <hr class="related__section-break" />
-            <h4 class="govuk-heading-m">Preview</h4>
+            <h4 class="govuk-heading-m">Preview on a course</h4>
             <p class="govuk-body">This information will show on all your courses.</p>
             <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
 
@@ -124,7 +124,7 @@
             <p class="govuk-body">You have unpublished changes.</p>
 
             <hr class="related__section-break" />
-            <h4 class="govuk-heading-m">Preview</h4>
+            <h4 class="govuk-heading-m">Preview on a course</h4>
             <p class="govuk-body">This information will show on all your courses.</p>
             <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
 
@@ -149,7 +149,7 @@
             <p class="govuk-body">You have unpublished changes.</p>
 
             <hr class="related__section-break" />
-            <h4 class="govuk-heading-m">Preview</h4>
+            <h4 class="govuk-heading-m">Preview on a course</h4>
             <p class="govuk-body">This information will show on all your courses.</p>
             <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
 
@@ -168,7 +168,7 @@
             <p class="govuk-body">You have unpublished changes.</p>
 
             <hr class="related__section-break" />
-            <h4 class="govuk-heading-m">Preview</h4>
+            <h4 class="govuk-heading-m">Preview on a course</h4>
             <p class="govuk-body">This information will show on all your courses.</p>
             <p class="govuk-body">Preview any course to see how it will look to applicants.</p>
 

--- a/src/ui/Views/Shared/CopyCourseContent.cshtml
+++ b/src/ui/Views/Shared/CopyCourseContent.cshtml
@@ -11,7 +11,7 @@
 }
 else
 {
-  <h4 class="govuk-heading-m">Use content from another course</h4>
+  <h4 class="govuk-heading-m">Copy content from another course</h4>
   <p class="govuk-body">Fill in this page with content from another course.</p>
   <p class="govuk-body">This will replace any existing content.</p>
   <form class="govuk-form" method="GET">


### PR DESCRIPTION
* Use "Copy" not "Use" on copying course feature
* Update About org preview title to refer to previewing on a course
* Add guidance if salary is unknown
* Indicate that you can edit after publish