### PR TITLE
recover from intermittent auth flow fails; fix broken image paths

### DIFF
--- a/src/ui/Startup.cs
+++ b/src/ui/Startup.cs
@@ -183,7 +183,7 @@ namespace GovUk.Education.ManageCourses.Ui
                     OnMessageReceived = context =>
                         {
                             var isSpuriousAuthCbRequest =
-                                context.Request.Path == new PathString("/auth/cb") &&
+                                context.Request.Path == options.CallbackPath &&
                                 context.Request.Method == "GET" &&
                                 !context.Request.Query.ContainsKey("code");
 

--- a/src/ui/Startup.cs
+++ b/src/ui/Startup.cs
@@ -183,7 +183,7 @@ namespace GovUk.Education.ManageCourses.Ui
                     OnMessageReceived = context =>
                         {
                             var isSpuriousAuthCbRequest =
-                                (context.Request.Path == new Microsoft.AspNetCore.Http.PathString("/auth/cb") || context.Request.Path == new Microsoft.AspNetCore.Http.PathString("/auth/cb/"))&&
+                                context.Request.Path == new PathString("/auth/cb") &&
                                 context.Request.Method == "GET" &&
                                 !context.Request.Query.ContainsKey("code");
 
@@ -196,6 +196,17 @@ namespace GovUk.Education.ManageCourses.Ui
 
                             return Task.CompletedTask;
                         },
+
+                    // Sometimes the auth flow fails. The most commonly observed causes for this are
+                    // Cookie correlation failures, caused by obscure load balancing stuff.
+                    // In these cases, rather than send user to a 500 page, prompt them to re-authenticate.
+                    // This is derived from the recommended approach: https://github.com/aspnet/Security/issues/1165
+                    OnRemoteFailure = ctx =>
+                    {
+                        ctx.Response.Redirect("/");
+                        ctx.HandleResponse();
+                        return Task.FromResult(0);
+                    },
 
                     OnRedirectToIdentityProvider = context =>
                     {

--- a/src/ui/Views/Shared/_Layout_base.cshtml
+++ b/src/ui/Views/Shared/_Layout_base.cshtml
@@ -11,19 +11,14 @@
 
     <link rel="stylesheet" href="~/application.css" asp-append-version="true" />
 
-    <!--[if lt IE 9]>
-        <script src="/html5-shiv/html5shiv.js"></script>
-    <![endif]-->
-
     <link rel="shortcut icon" href="~/images/favicon.ico" type="image/x-icon" asp-append-version="true" />
-    <link rel="mask-icon" href="~/images/gov.uk_logotype_crown.svg" color="#0b0c0c" asp-append-version="true" />
-    <link rel="apple-touch-icon" sizes="180x180" href="~/images/apple-touch-icon-180x180.png" asp-append-version="true" />
-    <link rel="apple-touch-icon" sizes="167x167" href="~/images/apple-touch-icon-167x167.png" asp-append-version="true" />
-    <link rel="apple-touch-icon" sizes="152x152" href="~/images/apple-touch-icon-152x152.png" asp-append-version="true" />
-    <link rel="apple-touch-icon" href="~/images/apple-touch-icon.png" asp-append-version="true" />
+    <link rel="mask-icon" href="~/images/gov.uk-mask-icon.svg" color="#0b0c0c" asp-append-version="true" />
+    <link rel="apple-touch-icon" sizes="180x180" href="~/images/govuk-apple-touch-icon-180x180.png" asp-append-version="true" />
+    <link rel="apple-touch-icon" sizes="167x167" href="~/images/govuk-apple-touch-icon-167x167.png" asp-append-version="true" />
+    <link rel="apple-touch-icon" sizes="152x152" href="~/images/govuk-apple-touch-icon-152x152.png" asp-append-version="true" />
+    <link rel="apple-touch-icon" href="~/images/govuk-apple-touch-icon.png" asp-append-version="true" />
 
     <meta name="theme-color" content="#0b0c0c" />
-    <meta property="og:image" content="~/images/opengraph-image.png" />
 
     @RenderSection("head", required: false)
 </head>

--- a/src/ui/Views/Shared/_Layout_base.cshtml
+++ b/src/ui/Views/Shared/_Layout_base.cshtml
@@ -19,6 +19,7 @@
     <link rel="apple-touch-icon" href="~/images/govuk-apple-touch-icon.png" asp-append-version="true" />
 
     <meta name="theme-color" content="#0b0c0c" />
+    <meta property="og:image" content="~/images/govuk-opengraph-image.png" />
 
     @RenderSection("head", required: false)
 </head>


### PR DESCRIPTION
### Context

Now that we return status codes on the original route, a lot of the errors we've seen have been diagnosed and have relatively easy fixes.

### Changes proposed in this pull request

- fix up some image references in _Layout_base.cshtml - those have pointed to nonexistent images causing 404s
- remove the check for "/auth/cb/" - this path is not registered by the OIDC middelware and that bit of code didn't do anything. DfE Sign in are fixing the trailing slash on their end today
- add a handler for remote failure. The most common of these is a "Correlation failed" exception. [This](https://github.com/aspnet/Security/issues/1165) suggests that this is due to load balancing and the recommendation is to just restart the auth process, which we now do.

### Guidance to review
