### PR TITLE
Add margin right to inline tag when in paragraph

### DIFF
--- a/src/ui/Assets/Styles/components/_publish-tags.scss
+++ b/src/ui/Assets/Styles/components/_publish-tags.scss
@@ -17,4 +17,8 @@
 
 .govuk-tag--inline {
   margin-bottom: 0;
+
+  .govuk-body & {
+    margin-right: govuk-spacing(1);
+  }
 }


### PR DESCRIPTION
### Changes proposed in this pull request
Add space after inline tag

### Guidance to review
# After
<img width="1380" alt="screen shot 2018-09-12 at 14 26 10" src="https://user-images.githubusercontent.com/3071606/45427836-d1254e00-b697-11e8-83cb-30093638214c.png">
