### PR TITLE
Conditionally show org url

### DIFF
--- a/src/ui/Views/Organisation/Details.cshtml
+++ b/src/ui/Views/Organisation/Details.cshtml
@@ -53,7 +53,16 @@
               @Model.Telephone.DisplayText()
             </dd>
             <dt class="govuk-list--description__label">Website</dt>
-            <dd><a href="@Model.Url">@Model.Url</a></dd>
+            <dd class="@(string.IsNullOrWhiteSpace(Model.Url) ? "course-parts__fields__value--empty" : "")">
+              @if (!String.IsNullOrWhiteSpace(Model.Url))
+              {
+                <a href="@Model.Url" class="govuk-link">@Model.Url.DisplayText()</a>
+              }
+              else
+              {
+                @Model.Url.DisplayText()
+              }
+            </dd>
             <dt class="govuk-list--description__label">Address</dt>
             <dd>
               @if (!String.IsNullOrWhiteSpace(Model.Addr1))


### PR DESCRIPTION
### Context
Org contact info

### Changes proposed in this pull request
Some orgs don't have an URL

### Guidance to review
# After
<img width="1380" alt="screen shot 2018-09-12 at 16 30 12" src="https://user-images.githubusercontent.com/3071606/45435776-2453cc80-b6a9-11e8-95e5-8a6d60a43d83.png">
<img width="1380" alt="screen shot 2018-09-12 at 16 30 04" src="https://user-images.githubusercontent.com/3071606/45435777-24ec6300-b6a9-11e8-8d4d-eabd0a025f18.png">

