### PR TITLE
Add info about org contact details

### DIFF
--- a/src/ui/Views/Organisation/Details.cshtml
+++ b/src/ui/Views/Organisation/Details.cshtml
@@ -34,6 +34,9 @@
       <div class="course-parts">
         <div class="course-parts__item">
           <h3 class="course-parts__title">Contact details from UCAS</h3>
+          <p class="govuk-body">
+            We’ve imported these details from UCAS Entry Profiles. You’ll soon be able to edit them in this service. To make any changes to them now, email us at <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Update organisation contact details">becomingateacher@digital.education.gov.uk</a>.
+          </p>
           <dl class="govuk-list--description" role="contentinfo">
             <dt class="govuk-list--description__label">Training provider code</dt>
             <dd>@Model.InstitutionCode.ToUpper()</dd>


### PR DESCRIPTION
### Context
Users need to know how they can update their org contact info

### Changes proposed in this pull request
Add information about updating org contact details

### Guidance to review
# After
<img width="1380" alt="screen shot 2018-09-13 at 12 34 30" src="https://user-images.githubusercontent.com/3071606/45485966-65072080-b751-11e8-997f-520438a8ff2b.png">
