### PR TITLE
add user ids to app insights

### DIFF
--- a/src/ui/Startup.cs
+++ b/src/ui/Startup.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ManageCourses.Ui.ActionFilters;
 using GovUk.Education.ManageCourses.Ui.Services;
 using GovUk.Education.SearchAndCompare.UI.Shared.ViewComponents;
 using IdentityModel.Client;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
@@ -249,6 +250,8 @@ namespace GovUk.Education.ManageCourses.Ui
             services.AddSingleton<ManageCoursesConfig, ManageCoursesConfig>();
             services.AddSingleton<IManageApi, ManageApi>();
             services.AddScoped<ICourseMapper, CourseMapper>();
+            services.AddSingleton<ITelemetryInitializer, SubjectTelemetryInitialiser>();
+            services.AddApplicationInsightsTelemetry();
             services.AddSingleton(serviceProvider =>
             {
                 var manageCoursesApiClientConfiguration = serviceProvider.GetService<IManageCoursesApiClientConfiguration>();

--- a/src/ui/SubjectTelemetryInitialiser.cs
+++ b/src/ui/SubjectTelemetryInitialiser.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Http;
+
+namespace GovUk.Education.ManageCourses.Ui
+{
+    public class SubjectTelemetryInitialiser : ITelemetryInitializer
+    {
+        IHttpContextAccessor httpContextAccessor;
+
+        public SubjectTelemetryInitialiser(IHttpContextAccessor httpContextAccessor)
+        {
+            this.httpContextAccessor = httpContextAccessor;
+        }
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (httpContextAccessor.HttpContext?.User?.Identity?.IsAuthenticated == true)
+            {
+                var foo = httpContextAccessor.HttpContext.User.Identity as ClaimsIdentity;
+                var sub = foo.Claims.FirstOrDefault(x => x.Type == "sub");
+                if (sub != null)
+                {
+                    telemetry.Context.Properties["UserSubjectId"] = sub.Value;
+                }
+            }
+            
+        }
+    }
+}


### PR DESCRIPTION
### Context

https://trello.com/c/aZCtAqAE/314-set-userid-in-application-insights-manage-courses-ui-manage-courses-api

### Changes proposed in this pull request

Add a TelemetryInitializer that sets a custom property `UserSubjectId` to the subject id, if present.
