### PR TITLE
use floating version numbers

### DIFF
--- a/src/ui/ManageCoursesUi.csproj
+++ b/src/ui/ManageCoursesUi.csproj
@@ -29,7 +29,7 @@
   <Import Condition="Exists('$(ProjectDir)dev-sc-shared.targets')" Project="$(ProjectDir)dev-sc-shared.targets" />
 
   <ItemGroup Condition="Exists('$(ProjectDir)dev-mc-api.targets')==false">
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.13.0" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.13.0.*" />
   </ItemGroup>
   <ItemGroup Condition="Exists('$(ProjectDir)dev-sc-shared.targets')==false">
     <PackageReference Include="GovUk.Education.SearchAndCompare.Ui.Shared" Version="0.4.3.*" />


### PR DESCRIPTION
### Context

@fofr's comment in https://trello.com/c/mmeoQQuk/315-only-show-training-locations-set-to-running-on-course-preview

### Changes proposed in this pull request

We had pinned the version of the api client to the lowest revision - this restores the correct behaviour
