### PR TITLE
Add html5shiv

### DIFF
--- a/src/ui/Views/Shared/_Layout_base.cshtml
+++ b/src/ui/Views/Shared/_Layout_base.cshtml
@@ -11,6 +11,10 @@
 
     <link rel="stylesheet" href="~/application.css" asp-append-version="true" />
 
+    <!--[if lt IE 9]>
+      <script src="~/vendor/html5shiv.min.js" asp-append-version="true"></script>
+    <![endif]-->
+
     <link rel="shortcut icon" href="~/images/favicon.ico" type="image/x-icon" asp-append-version="true" />
     <link rel="mask-icon" href="~/images/gov.uk-mask-icon.svg" color="#0b0c0c" asp-append-version="true" />
     <link rel="apple-touch-icon" sizes="180x180" href="~/images/govuk-apple-touch-icon-180x180.png" asp-append-version="true" />

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -4336,6 +4336,12 @@
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
       "dev": true
     },
+    "html5shiv": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/html5shiv/-/html5shiv-3.7.3.tgz",
+      "integrity": "sha1-14qEo2e8uacQEA1XgCw4ewhGMdI=",
+      "dev": true
+    },
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -20,6 +20,7 @@
     "css-loader": "1.0.0",
     "form-serialize": "0.7.2",
     "govuk-frontend": "1.3.0",
+    "html5shiv": "^3.7.3",
     "mini-css-extract-plugin": "0.4.1",
     "node-sass": "4.9.3",
     "sass-loader": "7.1.0",

--- a/src/ui/webpack.config.js
+++ b/src/ui/webpack.config.js
@@ -52,6 +52,10 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
       {
         from: 'node_modules/govuk-frontend/assets/fonts',
         to: 'fonts'
+      },
+      {
+        from: 'node_modules/html5shiv/dist/html5shiv.min.js',
+        to: 'vendor'
       }
     ]),
   ],


### PR DESCRIPTION
### Context
Helping users on legacy browsers

> The HTML5 Shiv enables use of HTML5 sectioning elements in legacy Internet Explorer and provides basic HTML5 styling for Internet Explorer 6-9, Safari 4.x (and iPhone 3.x), and Firefox 3.x.

### Changes proposed in this pull request
Add html5shiv

### Guidance to review
View service on IE9 and see what happens ;-)
