### PR TITLE
Add course preview link when published

### DIFF
--- a/src/ui/Views/Course/Show.cshtml
+++ b/src/ui/Views/Course/Show.cshtml
@@ -198,7 +198,12 @@
           <p class="govuk-body">See how this course currently looks to applicants:</p>
           <p class="govuk-body"><a href="@Model.LiveSearchUrl">View on website</a></p>
         }
-
+        else
+        {
+          <h4 class="govuk-heading-m">Preview</h4>
+          <p class="govuk-body">See how this course looks:</p>
+          <p class="govuk-body"><a asp-action="Preview">Preview course</a></p>
+        }
       </aside>
     }
     </div>


### PR DESCRIPTION
### Context
When publishers click "publish" they can't view the course because we aren't pushing to search and compare _yet_.

### Changes proposed in this pull request
Show preview link even if course is published

### Guidance to review
# After
<img width="933" alt="screen shot 2018-09-17 at 16 10 43" src="https://user-images.githubusercontent.com/3071606/45632876-504ec380-ba96-11e8-867f-b95d3c0c37f8.png">
