### PR TITLE
set security headers in production

### DIFF
--- a/src/ui/ApplicationBuilderSecurityExtensions.cs
+++ b/src/ui/ApplicationBuilderSecurityExtensions.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Primitives;
+
+namespace GovUk.Education.ManageCourses.Ui
+{
+    public static class ApplicationBuilderSecurityExtensions
+    {
+        public static IApplicationBuilder SetSecurityHeaders(this IApplicationBuilder app)
+        {        
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers["X-Frame-Options"] = new StringValues("SAMEORIGIN");
+                context.Response.Headers["Strict-Transport-Security"] = new StringValues("31536000; preload");
+                await next();
+            });
+
+            return app;
+        }
+    }
+}

--- a/src/ui/Startup.cs
+++ b/src/ui/Startup.cs
@@ -274,6 +274,10 @@ namespace GovUk.Education.ManageCourses.Ui
                     HotModuleReplacement = true
                 });
             }
+            else
+            {
+                app.SetSecurityHeaders();
+            }
 
             app.UseStatusCodePagesWithReExecute("/error/{0}");
 


### PR DESCRIPTION
### Context

Quick fixes from the pen test

### Changes proposed in this pull request

Add two headers (`X-Frame-Options` and `Strict-Transport-Security`) that prevent clickjacking and man-in-the-middle attacks during the initial HTTP-->HTTPS redirect, respectively.