### PR TITLE
Make virtual path for html5shiv.js work

### DIFF
--- a/src/ui/Views/Shared/_Layout_base.cshtml
+++ b/src/ui/Views/Shared/_Layout_base.cshtml
@@ -10,9 +10,10 @@
     <title>@(ViewBag.Title ?? "Welcome to GOV.UK")</title>
 
     <link rel="stylesheet" href="~/application.css" asp-append-version="true" />
-
+    
+    @* Razor doesn't resolve virtual paths within comments, so we need to use Url.Content explicitly in this particular case *@
     <!--[if lt IE 9]>
-      <script src="~/vendor/html5shiv.min.js" asp-append-version="true"></script>
+      <script src="@Url.Content("~/vendor/html5shiv.min.js")" asp-append-version="true"></script>
     <![endif]-->
 
     <link rel="shortcut icon" href="~/images/favicon.ico" type="image/x-icon" asp-append-version="true" />


### PR DESCRIPTION
ASP.NET core razor has a limitation that vitual file paths such as
`~/vendor/html5shiv.js` only get expanded if they are not in comments,
including browser guard clause comments.

If you want to expand a virtual path in comments you have to call
@Url.Content(path) explicitly, e.g. `@Url.Content("~/vendor/html5shiv.js")`
