### PR TITLE
Allow users to set Accrediting Provider description to empty

### DIFF
--- a/src/ui/Controllers/OrganisationController.cs
+++ b/src/ui/Controllers/OrganisationController.cs
@@ -232,8 +232,14 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
 
                         var aboutTrainingProviders = (fromModel ?? new List<TrainingProviderViewModel>());
 
-                        description = aboutTrainingProviders.FirstOrDefault(
-                            atp => (atp.InstitutionCode.Equals(x.AccreditingProviderId, StringComparison.InvariantCultureIgnoreCase)))?.Description ?? description;
+                        var newAccreditingProviderModel = aboutTrainingProviders.FirstOrDefault(
+                            atp => (atp.InstitutionCode.Equals(x.AccreditingProviderId, StringComparison.InvariantCultureIgnoreCase)));
+                            
+                        if (newAccreditingProviderModel != null)
+                        {
+                            // empty descriptions get bound as `null` by ASP.NET MVC model binding
+                            description = newAccreditingProviderModel.Description ?? "";
+                        }
                         
                         var tpvm = new TrainingProviderViewModel()
                         {


### PR DESCRIPTION
### Context

https://trello.com/c/AV64Sg7C/378-cannot-set-previously-populated-accredited-provider-info-to-empty

### Changes proposed in this pull request

We misinterpreted a `null` for an accrediting provider description
in the Org Enrichment model to mean "use what's already in place".

This commit fixes that and provides a regression test.

### Guidance to review
