### PR TITLE
Apprenticeships are salaried

### DIFF
--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -62,7 +62,8 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         public async Task<IActionResult> ShowPublish(string instCode, string accreditingProviderId, string ucasCode)
         {
             var course = await _manageApi.GetCourseByUcasCode(instCode, ucasCode);
-            var isSalary = course.ProgramType.Equals("SS", StringComparison.InvariantCultureIgnoreCase);
+            var isSalary = course.ProgramType.Equals("SS", StringComparison.InvariantCultureIgnoreCase)
+                        || course.ProgramType.Equals("TA", StringComparison.InvariantCultureIgnoreCase);
             var enrichment = await _manageApi.GetEnrichmentCourse(instCode, ucasCode);
             var enrichmentModel = GetCourseEnrichmentViewModel(enrichment, isSalary);
 
@@ -458,7 +459,8 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                     })
                 };
 
-            var isSalary = course.ProgramType.Equals("SS", StringComparison.InvariantCultureIgnoreCase);
+            var isSalary = course.ProgramType.Equals("SS", StringComparison.InvariantCultureIgnoreCase)
+                        || course.ProgramType.Equals("TA", StringComparison.InvariantCultureIgnoreCase);
             var courseEnrichmentViewModel = GetCourseEnrichmentViewModel(ucasCourseEnrichmentGetModel, isSalary, routeData);
             var viewModel = new VariantViewModel
             {

--- a/src/ui/Helpers/ViewModelHelpers.cs
+++ b/src/ui/Helpers/ViewModelHelpers.cs
@@ -24,7 +24,8 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
 
             result += GetStudyModeText(course.StudyMode);
 
-            result += string.Equals(course.ProgramType, "ss", StringComparison.InvariantCultureIgnoreCase) 
+            result += (string.Equals(course.ProgramType, "ss", StringComparison.InvariantCultureIgnoreCase) 
+                    || string.Equals(course.ProgramType, "ta", StringComparison.InvariantCultureIgnoreCase))
                 ? " with salary" 
                 : "";
 


### PR DESCRIPTION
### Context

https://trello.com/c/vmeOSUpF/339-incorrectly-showing-apprenticeship-as-fee-paying

### Changes proposed in this pull request

We currently only consider `school direct (salaried)` courses as having
a salary, but this applies to Apprenticeships too: They draw a salary
and don't take fees ([source](https://www.ucas.com/teaching-option/postgraduate-teaching-apprenticeship))

this corrects enrichment rendering to reflect that

### Guidance to review
