### PR TITLE
Fix session timeout - set session length to 6 hours

### DIFF
--- a/src/ui/Startup.cs
+++ b/src/ui/Startup.cs
@@ -63,7 +63,7 @@ namespace GovUk.Education.ManageCourses.Ui
 
             }).AddCookie(options =>
             {
-                options.ExpireTimeSpan = TimeSpan.FromMinutes(120);
+                options.ExpireTimeSpan = TimeSpan.FromHours(6);
                 options.Events = new CookieAuthenticationEvents
                 {
 
@@ -231,11 +231,6 @@ namespace GovUk.Education.ManageCourses.Ui
 
                         // so that we don't issue a session cookie but one with a fixed expiration
                         x.Properties.IsPersistent = true;
-
-                        // align expiration of the cookie with expiration of the
-                        // access token
-                        var accessToken = new JwtSecurityToken(x.TokenEndpointResponse.IdToken);
-                        x.Properties.ExpiresUtc = accessToken.ValidTo;
 
                         return Task.CompletedTask;
                     }


### PR DESCRIPTION
### Context

https://trello.com/c/6aTKejHj/386-enrichment-lost-when-saved-after-dfe-sign-in-timeout#

### Changes proposed in this pull request

There was an error in our cookie logic. We set the cookie lifetime
to equal the access_token lifetime. This meant that we lost access to the
cookie and the refresh token as soon as the access_token expired.
As a consequence, we never had a chance to refresh.

This decouples cookie lifetime from access_token lifetime, setting
the session length to 6 hours.

### Guidance to review

This would benefit from some tests but the logic is so deep in .NET Core internals that I'm struggling to devise a sane test for it.

I haven't addressed the point that session length is not configurable in this PR (to me it didn't seem like a particularly valuable config to extract)
