### PR TITLE
Refine the course type label for apprenticeships

### DIFF
--- a/src/ui/Helpers/ViewModelHelpers.cs
+++ b/src/ui/Helpers/ViewModelHelpers.cs
@@ -24,11 +24,14 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
 
             result += GetStudyModeText(course.StudyMode);
 
-            result += (string.Equals(course.ProgramType, "ss", StringComparison.InvariantCultureIgnoreCase) 
-                    || string.Equals(course.ProgramType, "ta", StringComparison.InvariantCultureIgnoreCase))
+            result += string.Equals(course.ProgramType, "ss", StringComparison.InvariantCultureIgnoreCase)
                 ? " with salary" 
                 : "";
 
+            result += string.Equals(course.ProgramType, "ta", StringComparison.InvariantCultureIgnoreCase)
+                ? " teaching apprenticeship" 
+                : "";
+            
             return result;
         }
         public static string GetCourseStatus(this Course course)


### PR DESCRIPTION
We should explicitly label apprenticeships to set them apart from salaried courses.