### PR TITLE
Use Course.TypeDescription from API rather than generating it on UI

### DIFF
--- a/ManageCoursesUi.Tests/ViewModelHelperTests.cs
+++ b/ManageCoursesUi.Tests/ViewModelHelperTests.cs
@@ -14,37 +14,6 @@ namespace ManageCoursesUi.Tests
     class ViewModelHelperTests
     {
         [Test]
-        [TestCase("", "f", "ss", "QTS full time with salary")]
-        [TestCase("", "F", "SS", "QTS full time with salary")]
-        [TestCase(null, "f", "ss", "QTS full time with salary")]
-        [TestCase(null, "F", "SS", "QTS full time with salary")]
-        [TestCase("pg", "f", "ss", "PGCE with QTS full time with salary")]
-        [TestCase("PG", "F", "SS", "PGCE with QTS full time with salary")]
-        [TestCase("pg", "p", "ss", "PGCE with QTS part time with salary")]
-        [TestCase("PG", "P", "SS", "PGCE with QTS part time with salary")]
-        [TestCase("", "f", "sd", "QTS full time")]
-        [TestCase("", "F", "SD", "QTS full time")]
-        [TestCase(null, "f", "sd", "QTS full time")]
-        [TestCase(null, "F", "SD", "QTS full time")]
-        [TestCase("pg", "f", "sd", "PGCE with QTS full time")]
-        [TestCase("PG", "F", "SD", "PGCE with QTS full time")]
-        [TestCase("pg", "p", "sd", "PGCE with QTS part time")]
-        [TestCase("PG", "P", "SD", "PGCE with QTS part time")]
-        [TestCase("PG", "B", "SD", "PGCE with QTS, full time or part time")]
-        [TestCase("pg", "b", "sd", "PGCE with QTS, full time or part time")]
-        public void TestGetCourseVariantType(string profpostFlag, string studyMode, string programType, string expectedResult)
-        {
-            var course = new Course
-            {
-                ProfpostFlag = profpostFlag,
-                StudyMode = studyMode,
-                ProgramType = programType
-            };
-            var result = course.GetCourseVariantType();
-            result.Should().Be(expectedResult);
-        }
-
-        [Test]
         [TestCase("N", "N", "N", "N", "New – not yet running")]
         [TestCase("N", "N", "S", "S", "New – not yet running")]
         [TestCase("N", "S", "S", "S", "New – not yet running")]

--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -410,7 +410,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                 new CourseVariantViewModel
                 {
                     Name = course.Name,
-                    Type = course.GetCourseVariantType(),
+                    Type = course.TypeDescription,
                     Accrediting = course.AccreditingProviderName,
                     ProviderCode = course.AccreditingProviderId,
                     ProgrammeCode = course.CourseCode,

--- a/src/ui/Helpers/ViewModelHelpers.cs
+++ b/src/ui/Helpers/ViewModelHelpers.cs
@@ -8,32 +8,7 @@ using GovUk.Education.ManageCourses.Ui.ViewModels;
 namespace GovUk.Education.ManageCourses.Ui.Helpers
 {
     public static class ViewModelHelpers
-    {
-        public static string GetCourseVariantType(this Course course)
-        {
-            var result = string.IsNullOrWhiteSpace(course.ProfpostFlag) ? "QTS" : "PGCE with QTS";
-
-            if ((!string.IsNullOrWhiteSpace(result)) && string.Equals(course.StudyMode, "B", StringComparison.InvariantCultureIgnoreCase))
-            {
-                result += ", ";
-            }
-            else
-            {
-                result += " ";
-            }
-
-            result += GetStudyModeText(course.StudyMode);
-
-            result += string.Equals(course.ProgramType, "ss", StringComparison.InvariantCultureIgnoreCase)
-                ? " with salary" 
-                : "";
-
-            result += string.Equals(course.ProgramType, "ta", StringComparison.InvariantCultureIgnoreCase)
-                ? " teaching apprenticeship" 
-                : "";
-            
-            return result;
-        }
+    {        
         public static string GetCourseStatus(this Course course)
         {
             var result = "";

--- a/src/ui/ManageCoursesUi.csproj
+++ b/src/ui/ManageCoursesUi.csproj
@@ -29,7 +29,7 @@
   <Import Condition="Exists('$(ProjectDir)dev-sc-shared.targets')" Project="$(ProjectDir)dev-sc-shared.targets" />
 
   <ItemGroup Condition="Exists('$(ProjectDir)dev-mc-api.targets')==false">
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.18.0.*" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.19.0.*" />
   </ItemGroup>
   <ItemGroup Condition="Exists('$(ProjectDir)dev-sc-shared.targets')==false">
     <PackageReference Include="GovUk.Education.SearchAndCompare.Ui.Shared" Version="0.4.12.*" />

--- a/src/ui/Views/Organisation/Show.cshtml
+++ b/src/ui/Views/Organisation/Show.cshtml
@@ -74,7 +74,7 @@
             <td class="govuk-table__cell">
               <a href="@Url.Action("show", "course", new {instCode = Model.InstitutionId, accreditingProviderId = course.AccreditingProviderId, ucasCode = course.CourseCode})" class="govuk-link">@course.Name (@course.CourseCode)</a>
             </td>
-            <td class="govuk-table__cell">@course.GetCourseVariantType()</td>
+            <td class="govuk-table__cell">@course.TypeDescription</td>
             <td class="govuk-table__cell">@course.GetCourseStatus()</td>
             <td class="govuk-table__cell">
               @if(course.CanHaveEnrichment())


### PR DESCRIPTION
### Context

Add support for PGDE courses

### Changes proposed in this pull request

Use the update from https://github.com/DFE-Digital/manage-courses-api/pull/181
to eliminate duplication in determining the "Type" of a course.

### Guidance to review
