### PR TITLE
Add helper text about viewing org info

### DIFF
--- a/src/ui/Views/Organisation/Details.cshtml
+++ b/src/ui/Views/Organisation/Details.cshtml
@@ -184,6 +184,10 @@
           case WorkflowStatus.Published :
             <strong class="govuk-tag govuk-tag--published">Published</strong>
             <p class="govuk-body">Last published on @Model.LastPublishedTimestampUtc.DateString()</p>
+            <hr class="related__section-break" />
+            <h4 class="govuk-heading-m">View on a course</h4>
+            <p class="govuk-body">This information will show on all your courses.</p>
+            <p class="govuk-body">View any course to see how it will look to applicants.</p>
 
             break;
           case WorkflowStatus.SubsequentDraft :


### PR DESCRIPTION
### Context
Once an org has been "published" there are no instructions on how user can view the information

### Changes proposed in this pull request
Display helper text when an org is published

### Guidance to review
<img width="1392" alt="screen shot 2018-10-02 at 14 50 17" src="https://user-images.githubusercontent.com/3071606/46352796-8d988100-c652-11e8-85c9-2f8c2a77ac44.png">
