### PR TITLE
Add Provider code to "Problem with course" mail

### DIFF
--- a/src/ui/Views/Course/Show.cshtml
+++ b/src/ui/Views/Course/Show.cshtml
@@ -3,7 +3,7 @@
 @{
   Layout = "_Layout";
   ViewBag.Title = Model.Course.Name;
-  var link = "mailto:becomingateacher@digital.education.gov.uk?subject=Problem%20with%20course%20" + Model.Course.ProgrammeCode;
+  var link = $"mailto:becomingateacher@digital.education.gov.uk?subject=Problem%20with%20course%20{Model.Course.ProviderCode}%20{Model.Course.ProgrammeCode}";
 
   var courseEnrichment = Model.CourseEnrichment;
   var routeData = courseEnrichment.RouteData;


### PR DESCRIPTION
### Context

Zendesk tickets omitting provider codes are driving support (esp me) insane.

### Changes proposed in this pull request

This adds the ProviderCode aka InstCode to the email subject
