### PR TITLE
Update published success messages

### DIFF
--- a/ManageCoursesUi.Tests/CourseControllerTests.cs
+++ b/ManageCoursesUi.Tests/CourseControllerTests.cs
@@ -248,7 +248,7 @@ namespace ManageCoursesUi.Tests
             objectValidator.VerifyAll();
 
             Assert.AreEqual("success", courseController.TempData["MessageType"]);
-            Assert.AreEqual("Your changes will be published within 1 working day, usually within 2 hours", courseController.TempData["MessageTitle"]);
+            Assert.AreEqual("Your course has been published", courseController.TempData["MessageTitle"]);
 
             Assert.IsNotNull(objectToVerify);
             Assert.AreEqual("AboutCourse", objectToVerify.AboutCourse);

--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -81,7 +81,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
 
                 if (featureFlags.ShowCourseLiveView)
                 {
-                    TempData["MessageTitle"] = "Your changes will be published within 1 working day, usually within 2 hours";
+                    TempData["MessageTitle"] = "Your course has been published";
                     var searchUrl = searchAndCompareUrlService.GetCoursePageUri(course.InstCode, course.CourseCode);
                     TempData["MessageBodyHtml"] = $@"
                         <p class=""govuk-body"">

--- a/src/ui/Controllers/OrganisationController.cs
+++ b/src/ui/Controllers/OrganisationController.cs
@@ -278,7 +278,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                 {
 
                     TempData["MessageType"] = "success";
-                    TempData["MessageTitle"] = "Your changes will be published within 1 working day, usually within 2 hours";
+                    TempData["MessageTitle"] = "Your changes have been published – this content will appear on all of your course pages";
 
                     return RedirectToAction("Details", new { ucasCode });
                 }


### PR DESCRIPTION
### Context
Now that publishing is synchronous, when a publisher hits "Publish", the success message shouldn't mention any delays.

### Changes proposed in this pull request
Update the microcopy on the success messages - paired with Paul G on it.
