### PR TITLE
Use VacStatus field in frontend

### DIFF
--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -144,7 +144,8 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
             {
                 copyFrom = copyFrom.ToUpper();
                 var copiedEnrichment = await _manageApi.GetEnrichmentCourse(instCode, copyFrom);
-                ViewBag.CopiedFrom = new CourseInfoViewModel {
+                ViewBag.CopiedFrom = new CourseInfoViewModel
+                {
                     ProgrammeCode = copyFrom,
                     Name = (ViewBag.CopyableCourses as IEnumerable<ApiClient.Course>).SingleOrDefault(x => x.CourseCode == copyFrom)?.Name
                 };
@@ -214,7 +215,8 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
             {
                 copyFrom = copyFrom.ToUpper();
                 var copiedEnrichment = await _manageApi.GetEnrichmentCourse(instCode, copyFrom);
-                ViewBag.CopiedFrom = new CourseInfoViewModel {
+                ViewBag.CopiedFrom = new CourseInfoViewModel
+                {
                     ProgrammeCode = copyFrom,
                     Name = (ViewBag.CopyableCourses as IEnumerable<ApiClient.Course>).SingleOrDefault(x => x.CourseCode == copyFrom)?.Name
                 };
@@ -274,7 +276,8 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
             {
                 copyFrom = copyFrom.ToUpper();
                 var copiedEnrichment = await _manageApi.GetEnrichmentCourse(instCode, copyFrom);
-                ViewBag.CopiedFrom = new CourseInfoViewModel {
+                ViewBag.CopiedFrom = new CourseInfoViewModel
+                {
                     ProgrammeCode = copyFrom,
                     Name = (ViewBag.CopyableCourses as IEnumerable<ApiClient.Course>).SingleOrDefault(x => x.CourseCode == copyFrom)?.Name
                 };
@@ -320,8 +323,8 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
             var model = new CourseFeesEnrichmentViewModel
             {
                 CourseLength = enrichmentModel?.CourseLength.GetCourseLength(),
-		        CourseLengthInput = enrichmentModel.CourseLength.GetCourseLengthInput(),
-		        FeeUkEu = enrichmentModel?.FeeUkEu.GetFeeValue(),
+                CourseLengthInput = enrichmentModel.CourseLength.GetCourseLengthInput(),
+                FeeUkEu = enrichmentModel?.FeeUkEu.GetFeeValue(),
                 FeeInternational = enrichmentModel?.FeeInternational.GetFeeValue(),
                 FeeDetails = enrichmentModel?.FeeDetails,
                 FinancialSupport = enrichmentModel?.FinancialSupport,
@@ -335,7 +338,8 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
             {
                 copyFrom = copyFrom.ToUpper();
                 var copiedEnrichment = await _manageApi.GetEnrichmentCourse(instCode, copyFrom);
-                ViewBag.CopiedFrom = new CourseInfoViewModel {
+                ViewBag.CopiedFrom = new CourseInfoViewModel
+                {
                     ProgrammeCode = copyFrom,
                     Name = (ViewBag.CopyableCourses as IEnumerable<ApiClient.Course>).SingleOrDefault(x => x.CourseCode == copyFrom)?.Name
                 };

--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -446,7 +446,8 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
                             Code = campus.Code,
                             LocationName = campus.LocationName,
                             Address = address,
-                            Status = campus.Status
+                            Status = campus.Status,
+                            VacStatus = campus.VacStatus
                         };
                     })
                 };

--- a/src/ui/Helpers/ViewModelHelpers.cs
+++ b/src/ui/Helpers/ViewModelHelpers.cs
@@ -52,6 +52,28 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
             }
             return result;
         }
+
+        public static string GetVacancyStatus(this SchoolViewModel school)
+        {
+            var result = "";
+            switch (school.VacStatus?.ToLower())
+            {
+                case "b":
+                    result = "Both full time and part time vacancies";
+                    break;
+                case "p":
+                    result = "Part time vacancies";
+                    break;
+                case "f":
+                    result = "Full time vacancies";
+                    break;
+                default:
+                    result = "No vacancies";
+                    break;
+            }
+            return result;
+        }
+
         public static string GetRoute(this CourseVariantViewModel viewModel)
         {
             var result = "";

--- a/src/ui/Helpers/ViewModelHelpers.cs
+++ b/src/ui/Helpers/ViewModelHelpers.cs
@@ -8,7 +8,7 @@ using GovUk.Education.ManageCourses.Ui.ViewModels;
 namespace GovUk.Education.ManageCourses.Ui.Helpers
 {
     public static class ViewModelHelpers
-    {        
+    {
         public static string GetCourseStatus(this Course course)
         {
             var result = "";
@@ -31,7 +31,7 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
         {
             return course != null && course.GetCourseStatus() != "Not running";
         }
-        
+
         public static string GetSchoolStatus(this SchoolViewModel school)
         {
             var result = "";
@@ -107,7 +107,7 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
             if (string.IsNullOrEmpty(viewModel.AgeRange)) return result;
 
             var ageRange = viewModel.AgeRange.Trim().ToLowerInvariant();
-            
+
             switch (ageRange)
             {
                 case "s":
@@ -145,29 +145,29 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
             switch (qualifications)
             {
                 case "pf":
-                {
-                    result = "Professional";
-                    break;
-                }
-                case "pg":
-                {
-                    result = "Postgraduate";
-                    break;
-                }
-                case "bo":
-                {
-                    result = "Professional/Postgraduate";
-                    break;
-                }
-                case "":
-                {
-                    result = "Recommendation for QTS";
+                    {
+                        result = "Professional";
                         break;
-                }
+                    }
+                case "pg":
+                    {
+                        result = "Postgraduate";
+                        break;
+                    }
+                case "bo":
+                    {
+                        result = "Professional/Postgraduate";
+                        break;
+                    }
+                case "":
+                    {
+                        result = "Recommendation for QTS";
+                        break;
+                    }
                 default:
-                {
-                    break;
-                }
+                    {
+                        break;
+                    }
             }
 
             return result;
@@ -205,4 +205,3 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
 
     }
 }
-

--- a/src/ui/Helpers/ViewModelHelpers.cs
+++ b/src/ui/Helpers/ViewModelHelpers.cs
@@ -74,6 +74,11 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
             return result;
         }
 
+        public static string GetHasVacancies(this Course course)
+        {
+            return course.HasVacancies ? "Yes" : "No";
+        }
+
         public static string GetRoute(this CourseVariantViewModel viewModel)
         {
             var result = "";

--- a/src/ui/ManageCoursesUi.csproj
+++ b/src/ui/ManageCoursesUi.csproj
@@ -29,7 +29,7 @@
   <Import Condition="Exists('$(ProjectDir)dev-sc-shared.targets')" Project="$(ProjectDir)dev-sc-shared.targets" />
 
   <ItemGroup Condition="Exists('$(ProjectDir)dev-mc-api.targets')==false">
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.21.0.*" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="0.21.1.*" />
   </ItemGroup>
   <ItemGroup Condition="Exists('$(ProjectDir)dev-sc-shared.targets')==false">
     <PackageReference Include="GovUk.Education.SearchAndCompare.Ui.Shared" Version="0.5.0.*" />

--- a/src/ui/ViewModels/FromUcasViewModel.cs
+++ b/src/ui/ViewModels/FromUcasViewModel.cs
@@ -50,8 +50,7 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         public string Address { get; set; }
         public string Code { get; set; }
         public string Status { get; set; }
-        public string FullTimeVacancies { get; set; }
-        public string PartTimeVacancies { get; set; }
+        public string VacStatus { get; set; }
 
         private string _applicationsAcceptedFrom;
         public string ApplicationsAcceptedFrom

--- a/src/ui/ViewModels/FromUcasViewModel.cs
+++ b/src/ui/ViewModels/FromUcasViewModel.cs
@@ -6,7 +6,7 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
 {
     public class VariantViewModel
     {
-        public bool AllowLiveView { get;  set; }
+        public bool AllowLiveView { get; set; }
         public string OrganisationName { get; set; }
         public string OrganisationId { get; set; }
         public bool MultipleOrganisations { get; set; }

--- a/src/ui/Views/Course/Show.cshtml
+++ b/src/ui/Views/Course/Show.cshtml
@@ -121,6 +121,11 @@
                 <dt>Status:</dt>
                 <dd>@school.GetSchoolStatus()</dd>
               }
+              @if (!string.IsNullOrEmpty(@school.VacStatus))
+              {
+                <dt>Vacancies:</dt>
+                <dd>@school.GetVacancyStatus()</dd>
+              }
               @if (!string.IsNullOrEmpty(@school.ApplicationsAcceptedFrom)) {
                 <dt>Apply from:</dt>
                 <dd>@school.ApplicationsAcceptedFrom</dd>

--- a/src/ui/Views/Organisation/Show.cshtml
+++ b/src/ui/Views/Organisation/Show.cshtml
@@ -65,6 +65,7 @@
             <th class="govuk-table__header ucas-info-table__type-col" scope="col">Type</th>
             <th class="govuk-table__header ucas-info-table__status-col" scope="col">Status</th>
             <th class="govuk-table__header ucas-info-table__content-status-col" scope="col">Course content</th>
+            <th class="govuk-table__header ucas-info-table__has-vancancies-col" scope="col">Has Vacancies</th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
@@ -93,6 +94,7 @@
                 }
               }
             </td>
+            <td class="govuk-table__cell">@course.GetHasVacancies()</td>
           </tr>
         }
         </tbody>


### PR DESCRIPTION
### Context

To reassure providers that DfE Publish has imported the up-to-date vacancy info from UCAS.

### Changes proposed in this pull request

This is from the latest version of the API, and depends on https://github.com/DFE-Digital/manage-courses-api/pull/190.

### Guidance to review

The build will fail until the API PR is merged.

### Screenshots after

#### Course page

<img width="670" alt="screenshot 2018-10-15 at 15 42 04" src="https://user-images.githubusercontent.com/1650875/46959049-08ba5800-d093-11e8-8c62-9808d5c9a073.png">

#### Overview page

<img width="1039" alt="screenshot 2018-10-15 at 15 55 05" src="https://user-images.githubusercontent.com/1650875/46959050-08ba5800-d093-11e8-9822-52fdc53bc8a9.png">
