### PR TITLE
Display empty string for vacancies when course is discontinued

### DIFF
--- a/ManageCoursesUi.Tests/ViewModelHelperTests.cs
+++ b/ManageCoursesUi.Tests/ViewModelHelperTests.cs
@@ -86,6 +86,28 @@ namespace ManageCoursesUi.Tests
         }
 
         [Test]
+        [TestCase("d", true, "")]
+        [TestCase("d", false, "")]
+        [TestCase("s", true, "")]
+        [TestCase("s", false, "")]
+        [TestCase("b", true, "Yes")]
+        [TestCase("b", false, "No")]
+        public void TestGetHasVacancies(string status, bool hasVacancies, string expectedResult)
+        {
+            var schools = new List<School>
+            {
+                new School {Status = status},
+            };
+            var course = new Course
+            {
+                Schools = new ObservableCollection<School>(schools),
+                HasVacancies = hasVacancies
+            };
+            var result = course.GetHasVacancies();
+            result.Should().Be(expectedResult);
+        }
+
+        [Test]
         [TestCase("HE", "Higher education programme")]
         [TestCase("he", "Higher education programme")]
         [TestCase("SD", "School Direct training programme")]

--- a/ManageCoursesUi.Tests/ViewModelHelperTests.cs
+++ b/ManageCoursesUi.Tests/ViewModelHelperTests.cs
@@ -80,7 +80,7 @@ namespace ManageCoursesUi.Tests
         [TestCase("", "")]
         public void TestGetSchoolStatus(string status, string expectedResult)
         {
-            var schoolViewModel = new SchoolViewModel{Status = status};
+            var schoolViewModel = new SchoolViewModel { Status = status };
             var result = schoolViewModel.GetSchoolStatus();
             result.Should().Be(expectedResult);
         }
@@ -97,7 +97,7 @@ namespace ManageCoursesUi.Tests
         [TestCase("", "")]
         public void TestGetRoute(string route, string expectedResult)
         {
-            var courseVariantViewModel = new CourseVariantViewModel{Route = route};
+            var courseVariantViewModel = new CourseVariantViewModel { Route = route };
             var result = courseVariantViewModel.GetRoute();
             result.Should().Be(expectedResult);
         }
@@ -143,6 +143,6 @@ namespace ManageCoursesUi.Tests
             var courseVariantViewModel = new CourseVariantViewModel { Qualifications = qualification };
             var result = courseVariantViewModel.GetQualification();
             result.Should().Be(expectedResult);
-        }        
+        }
     }
 }

--- a/src/ui/Helpers/ViewModelHelpers.cs
+++ b/src/ui/Helpers/ViewModelHelpers.cs
@@ -76,7 +76,9 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
 
         public static string GetHasVacancies(this Course course)
         {
-            return course.HasVacancies ? "Yes" : "No";
+            return CourseIsDiscontinuedOrSuspended(course)
+                ? ""
+                : course.HasVacancies ? "Yes" : "No";
         }
 
         public static string GetRoute(this CourseVariantViewModel viewModel)
@@ -230,5 +232,19 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
             return char.ToUpper(str[0]) + str.Substring(1).ToLower();
         }
 
+        private static bool CourseIsDiscontinuedOrSuspended(this Course course)
+        {
+            return course.Schools.All(s => SchoolIsDiscontinued(s) || SchoolIsSuspended(s));
+        }
+
+        private static bool SchoolIsDiscontinued(School school)
+        {
+            return String.Equals(school.Status, "d", StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        private static bool SchoolIsSuspended(School school)
+        {
+            return String.Equals(school.Status, "s", StringComparison.InvariantCultureIgnoreCase);
+        }
     }
 }


### PR DESCRIPTION
Discontinued courses shouldn't display vacancies.

### After

<img width="1066" alt="screenshot 2018-10-19 at 11 48 01" src="https://user-images.githubusercontent.com/1650875/47214112-de1f1680-d394-11e8-9723-e0f8393d20f2.png">
