### PR TITLE
Use new consistent api-url config key

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ bug in ASP.NET MVC Core which is using inconsistent package versions.
 You will need to set the app settings (preferred to be store as `user-secrets`):
 
 - **SearchAndCompare:UiBaseUrl** the location of the search and compare UI, for the purpose of linking, e.g. "https://find-postgraduate-teacher-training.gov.uk". Avoid trailing slash.
-- **ApiConnection:url** - the location of your [manage-courses-api](https://github.com/DFE-Digital/manage-courses-api) deployment. You can use a local one or perhaps [the one in the Dev Environment](https://manage-courses-ui-bat-development.e4ff.pro-eu-west-1.openshiftapps.com) if you are lazy
+- **API_URL** - the location of your [manage-courses-api](https://github.com/DFE-Digital/manage-courses-api) deployment. You can use a local one or perhaps [the one in the Dev Environment](https://manage-courses-ui-bat-development.e4ff.pro-eu-west-1.openshiftapps.com) if you are lazy
 - **DFE_SIGNIN_CLIENT_SECRET** - the client secret of your oath server
 - **auth:oidc:metadataAddress** - the .well-known config URL of your oauth server, if you don't want to use the default sandbox one
 - **auth:oidc:tokenEndpoint** - the /token endpoint as specified in the .well-known config URL of your oauth server

--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ It should be [12 factor](https://12factor.net/), notably config from environment
 
 - EITHER dotnet core, OR msbuid+Visual studio
 - Nodejs https://nodejs.org/ for the asset pipeline - worked with version 8.11.2 LTS
-- Access to a running instance of [manage-courses-api](https://github.com/DFE-Digital/manage-courses-api), e.g. [the dev one](https://manage-courses-ui-bat-development.e4ff.pro-eu-west-1.openshiftapps.com)
+- Access to a running instance of [manage-courses-api](https://github.com/DFE-Digital/manage-courses-api)
 - Access to an oauth server. To use the DfE Sign-in sandbox environment, ask the team for the current client secret, or get it from the DfE single sign-in project by emailing [DfE.SIGNIN@education.gov.uk](mailto:DfE.SIGNIN@education.gov.uk)
 
 ## Logging
@@ -51,7 +51,7 @@ bug in ASP.NET MVC Core which is using inconsistent package versions.
 You will need to set the app settings (preferred to be store as `user-secrets`):
 
 - **SearchAndCompare:UiBaseUrl** the location of the search and compare UI, for the purpose of linking, e.g. "https://find-postgraduate-teacher-training.gov.uk". Avoid trailing slash.
-- **API_URL** - the location of your [manage-courses-api](https://github.com/DFE-Digital/manage-courses-api) deployment. You can use a local one or perhaps [the one in the Dev Environment](https://manage-courses-ui-bat-development.e4ff.pro-eu-west-1.openshiftapps.com) if you are lazy
+- **API_URL** - the location of your [manage-courses-api](https://github.com/DFE-Digital/manage-courses-api) deployment. Defaults to development copy when in run in development mode.
 - **DFE_SIGNIN_CLIENT_SECRET** - the client secret of your oath server
 - **auth:oidc:metadataAddress** - the .well-known config URL of your oauth server, if you don't want to use the default sandbox one
 - **auth:oidc:tokenEndpoint** - the /token endpoint as specified in the .well-known config URL of your oauth server
@@ -91,7 +91,6 @@ The best way to set and store them is [user-secrets](https://docs.microsoft.com/
 ```powershell
 cd src\ui
 dotnet user-secrets set ASPNET_ENVIRONMENT Development
-dotnet user-secrets set ApiConnection:url https://manage-courses-api-bat-development.e4ff.pro-eu-west-1.openshiftapps.com
 dotnet user-secrets set DFE_SIGNIN_CLIENT_SECRET <the client secret>
 ```
 

--- a/src/ui/ManageCoursesConfig.cs
+++ b/src/ui/ManageCoursesConfig.cs
@@ -26,6 +26,6 @@ namespace GovUk.Education.ManageCourses.Ui
 
         public string ExternalRegistrationUrl => $"{ProfileBaseUrl}/register?client_id={ClientId}&redirect_uri={SiteBaseUrl}/{RegisterCallbackPath}";
 
-        public string ApiUrl => _configuration["ApiConnection:Url"];
+        public string ApiUrl => _configuration["API_URL"];
     }
 }

--- a/src/ui/ManageCoursesConfig.cs
+++ b/src/ui/ManageCoursesConfig.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System;
+using Microsoft.Extensions.Configuration;
 
 namespace GovUk.Education.ManageCourses.Ui
 {
     public class ManageCoursesConfig
     {
+        private const string ConfigKeyApiUrl = "API_URL";
         private readonly IConfiguration _configuration;
 
         public ManageCoursesConfig(IConfiguration configuration)
@@ -26,6 +28,15 @@ namespace GovUk.Education.ManageCourses.Ui
 
         public string ExternalRegistrationUrl => $"{ProfileBaseUrl}/register?client_id={ClientId}&redirect_uri={SiteBaseUrl}/{RegisterCallbackPath}";
 
-        public string ApiUrl => _configuration["API_URL"];
+        public string ApiUrl => _configuration[ConfigKeyApiUrl];
+
+
+        public void Validate()
+        {
+            if (string.IsNullOrWhiteSpace(ApiUrl))
+            {
+                throw new Exception($"Config value {ConfigKeyApiUrl} missing");
+            }
+        }
     }
 }

--- a/src/ui/Startup.cs
+++ b/src/ui/Startup.cs
@@ -297,7 +297,7 @@ namespace GovUk.Education.ManageCourses.Ui
                 .AddRedirect("^auth/cb/?.*", "auth/cb"));
 
             var config = serviceProvider.GetService<ManageCoursesConfig>();
-
+            config.Validate();
             _logger.LogInformation("Using API base URL: {0}", config.ApiUrl);
 
             app.UseMvc(routes =>

--- a/src/ui/appsettings.Development.json
+++ b/src/ui/appsettings.Development.json
@@ -17,7 +17,5 @@
     "site": "https://localhost:44364",
     "profile": "https://signin-test-pfl-as.azurewebsites.net"
   },
-  "ApiConnection": {
-    "Url": "http://localhost:6001/"
-  }
+  "API_URL": "http://localhost:6001/"
 }

--- a/src/ui/appsettings.Development.json
+++ b/src/ui/appsettings.Development.json
@@ -10,12 +10,12 @@
   "auth": {
     "oidc": {
       "metadataAddress": "https://signin-test-oidc-as.azurewebsites.net/.well-known/openid-configuration",
-      "tokenEndpoint" : "https://signin-test-oidc-as.azurewebsites.net/token"
+      "tokenEndpoint": "https://signin-test-oidc-as.azurewebsites.net/token"
     }
   },
   "url": {
     "site": "https://localhost:44364",
     "profile": "https://signin-test-pfl-as.azurewebsites.net"
   },
-  "API_URL": "http://localhost:6001/"
+  "API_URL": "https://bat-dev-manage-courses-api-app.azurewebsites.net/"
 }


### PR DESCRIPTION
### Context

Confusion from random variation in ways of configuring base api url.

This is the new consistent key name to rule them all.

Matching PR on search ui https://github.com/DFE-Digital/search-and-compare-ui/pull/249

### Changes proposed in this pull request

Use API_URL for the api url config instead of the odd nested thing.

