### PR TITLE
Bump shared UI dependency to v0.5.2.*

### DIFF
--- a/src/ui/ManageCoursesUi.csproj
+++ b/src/ui/ManageCoursesUi.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="1.0.0.*" />
   </ItemGroup>
   <ItemGroup Condition="Exists('$(ProjectDir)dev-sc-shared.targets')==false">
-    <PackageReference Include="GovUk.Education.SearchAndCompare.Ui.Shared" Version="0.5.1.*" />
+    <PackageReference Include="GovUk.Education.SearchAndCompare.Ui.Shared" Version="0.5.2.*" />
   </ItemGroup>
   <Target Name="Webpack" BeforeTargets="AfterBuild">
     <Exec Command="npm install" />


### PR DESCRIPTION
To get the unbroken preview (when `showMap` is not supplied in `viewbag`)

Pulls in https://github.com/DFE-Digital/search-and-compare-ui/pull/264
