### PR TITLE
Bumped version number reference

### DIFF
--- a/src/ui/ManageCoursesUi.csproj
+++ b/src/ui/ManageCoursesUi.csproj
@@ -28,7 +28,7 @@
   <Import Condition="Exists('$(ProjectDir)dev-sc-shared.targets')" Project="$(ProjectDir)dev-sc-shared.targets" />
 
   <ItemGroup Condition="Exists('$(ProjectDir)dev-mc-api.targets')==false">
-    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="3.0.0.*" />
+    <PackageReference Include="GovUk.Education.ManageCourses.ApiClient" Version="3.0.1.*" />
   </ItemGroup>
   <ItemGroup Condition="Exists('$(ProjectDir)dev-sc-shared.targets')==false">
     <PackageReference Include="GovUk.Education.SearchAndCompare.Ui.Shared" Version="0.5.3.*" />


### PR DESCRIPTION
### Context
This is part of the story to filter on SEN courses in Search And Compare
### Changes proposed in this pull request
We needed to ensure that the Api published this new flag to Search And Compare.
This has now been done and the Manage Courses Api has a new version number.
### Guidance to review
Updated version number for new Api