### PR TITLE
Tidy up courses table

### DIFF
--- a/src/ui/Assets/Styles/site.scss
+++ b/src/ui/Assets/Styles/site.scss
@@ -69,14 +69,13 @@ $success-green: #00823b;
     text-align: right;
   }
 
-  &__subject-col,
-  &__type-col {
-    width: 35%;
+  &__subject-col {
+    width: 50%;
   }
 
   &__status-col,
   &__content-status-col {
-    width: 15%;
+    width: 20%;
   }
 
   .govuk-table__row:last-child {
@@ -101,4 +100,3 @@ $success-green: #00823b;
   list-style-image: url('/images/dash.png');
   margin-bottom: govuk-spacing(8);
 }
-

--- a/src/ui/Views/Organisation/Show.cshtml
+++ b/src/ui/Views/Organisation/Show.cshtml
@@ -61,11 +61,10 @@
       <table class="ucas-info-table govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th class="govuk-table__header ucas-info-table__subject-col" scope="col">Subject</th>
-            <th class="govuk-table__header ucas-info-table__type-col" scope="col">Type</th>
+            <th class="govuk-table__header ucas-info-table__subject-col" scope="col">Course</th>
             <th class="govuk-table__header ucas-info-table__status-col" scope="col">Status</th>
-            <th class="govuk-table__header ucas-info-table__content-status-col" scope="col">Course content</th>
-            <th class="govuk-table__header ucas-info-table__has-vancancies-col" scope="col">Has Vacancies</th>
+            <th class="govuk-table__header ucas-info-table__content-status-col" scope="col">Content</th>
+            <th class="govuk-table__header ucas-info-table__has-vancancies-col" scope="col">Vacancies</th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
@@ -73,9 +72,9 @@
         {
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              <a href="@Url.Action("show", "course", new {providerCode = Model.ProviderCode, accreditingInstCode = course.AccreditingProvider?.ProviderCode, courseCode = course.CourseCode})" class="govuk-link">@course.Name (@course.CourseCode)</a>
+              <a href="@Url.Action("show", "course", new {providerCode = Model.ProviderCode, accreditingInstCode = course.AccreditingProvider?.ProviderCode, courseCode = course.CourseCode})" class="govuk-heading-s govuk-!-margin-0">@course.Name (@course.CourseCode)</a>
+              <span class="govuk-body-s">@course.TypeDescription</span>
             </td>
-            <td class="govuk-table__cell">@course.TypeDescription</td>
             <td class="govuk-table__cell">@course.GetCourseStatus()</td>
             <td class="govuk-table__cell">
               @if(course.CanHaveEnrichment())


### PR DESCRIPTION
* Highlight course titles
* Move type beneath course title
* Give more space for long title and type text
* Shorten table headings to avoid new lines

## New and old
![screen shot 2018-12-14 at 14 46 13](https://user-images.githubusercontent.com/319055/50009519-1a46b000-ffaf-11e8-983d-5296a9d43d01.png)

