### PR TITLE
Move suspended sites into details

### DIFF
--- a/src/ui/Views/Course/Show.cshtml
+++ b/src/ui/Views/Course/Show.cshtml
@@ -108,7 +108,7 @@
 
         <div class="course-parts__item">
           <h2 class="course-parts__title">Training locations</h2>
-          @foreach (var site in Model.Course.Sites)
+          @foreach (var site in Model.Course.Sites.Where(x => x.Status != "S"))
           {
             <h3 class="govuk-heading-s">@site.LocationName (Code: @site.Code)</h3>
             <dl class="govuk-list govuk-list--description">
@@ -129,6 +129,34 @@
               }
             </dl>
           }
+
+          @if(Model.Course.Sites.Where(x => x.Status == "S").Any()) {
+            <details class="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  There are @(Model.Course.Sites.Where(x => x.Status == "S").Count()) suspended or discontinued training locations for this course
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                @foreach (var site in Model.Course.Sites.Where(x => x.Status == "S"))
+                {
+                  <h3 class="govuk-heading-s">@site.LocationName (Code: @site.Code)</h3>
+                  <dl class="govuk-list govuk-list--description">
+                    @if (!string.IsNullOrEmpty(@site.Address)) {
+                      <dt>Address:</dt>
+                      <dd>@site.Address</dd>
+                    }
+                    @if (!string.IsNullOrEmpty(@site.Status))
+                    {
+                      <dt>Status:</dt>
+                      <dd>@site.GetSiteStatus()</dd>
+                    }
+                  </dl>
+                }
+              </div>
+            </details>
+          }
+
         </div>
       </div>
       <p class="govuk-body">


### PR DESCRIPTION
### Context
Provider users get confused when they see suspended and discontinued training locations

### Changes proposed in this pull request
Move suspended sites into details component

### Guidance to review
# After with suspended sites
<img width="391" alt="screen shot 2019-01-16 at 15 36 15" src="https://user-images.githubusercontent.com/3071606/51259656-7cc30f80-19a4-11e9-8edf-722591d489a0.png">

# After with 0 suspended sites
<img width="418" alt="screen shot 2019-01-16 at 15 36 03" src="https://user-images.githubusercontent.com/3071606/51259657-7d5ba600-19a4-11e9-993d-7b85e557c55f.png">
