### PR TITLE
967 Add additional link to footer, update give feedback content

### DIFF
--- a/src/ui/Assets/Styles/site.scss
+++ b/src/ui/Assets/Styles/site.scss
@@ -101,3 +101,8 @@ $success-green: #00823b;
   list-style-image: url('/images/dash.png');
   margin-bottom: govuk-spacing(8);
 }
+
+.govuk-footer__content {
+  @include govuk-font($size: 16, $line-height: 1.5);
+  color: $govuk-text-colour;
+}

--- a/src/ui/Views/Shared/_Layout.cshtml
+++ b/src/ui/Views/Shared/_Layout.cshtml
@@ -59,11 +59,21 @@
   </div>
 }
 
+@section footerTop {
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-footer__content-container">
+      <p class="govuk-footer__content">
+        <a class="govuk-footer__link" href="mailto:becomingateacher@digital.education.gov.uk">Contact the Becoming a Teacher team</a> for support.
+      </p>
+    </div>
+  </div>
+}
+
 @section footerSupportLinks {
   <h2 class="govuk-visually-hidden">Support links</h2>
   <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
     <li class="govuk-footer__inline-list-item">
-      <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Publish%20teacher%20training%20courses%20feedback" class="govuk-footer__link">Give feedback</a>
+      <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Publish%20teacher%20training%20courses%20feedback" class="govuk-footer__link">Give feedback or report a problem</a>
     </li>
     <li class="govuk-footer__inline-list-item">
       <a href="/cookies" class="govuk-footer__link">Cookies</a>


### PR DESCRIPTION
This allows users to search for contact, support, or problem in the page and find a useful link.

<img width="1440" alt="screenshot 2019-02-12 at 16 16 01" src="https://user-images.githubusercontent.com/1650875/52650217-b7579380-2ee1-11e9-8b48-635bcf7a9a8e.png">
