### PR TITLE
Fixed mismatch of courses listing and course page unpublished status

### DIFF
--- a/src/ui/Views/Course/Show.cshtml
+++ b/src/ui/Views/Course/Show.cshtml
@@ -232,7 +232,7 @@
             <div class="govuk-tag govuk-tag--empty">empty</div>
             break;
           case WorkflowStatus.SubsequentDraft:
-            <div class="govuk-tag govuk-tag--draft">draft</div>
+            <div class="govuk-tag govuk-tag--published">published *</div>
             break;
           case WorkflowStatus.Published:
             <div class="govuk-tag govuk-tag--published">published</div>
@@ -249,7 +249,7 @@
         @if (courseEnrichment.DeterminePublicationState() == WorkflowStatus.SubsequentDraft)
         {
           <div class="related__block">
-            <p class="govuk-body">You have unpublished changes.</p>
+            <p class="govuk-body">* You have unpublished changes.</p>
             <p class="govuk-body">Last saved:<br />@courseEnrichment.DraftLastUpdatedUtc.DateString()</p>
             @if (courseEnrichment.LastPublishedUtc.HasValue)
             {


### PR DESCRIPTION
### Context
mismatch of courses listing and course page unpublished status

course listing was showing Published * whereas course page was showing Draft

### Changes proposed in this pull request
Fixed mismatch of courses listing and course page unpublished status

### Guidance to review
courses listing
![image](https://user-images.githubusercontent.com/470137/52800910-aee39200-3074-11e9-9e72-97bf18c81d11.png)

course details
![image](https://user-images.githubusercontent.com/470137/52800822-7643b880-3074-11e9-807c-0c4d97261a28.png)
