### PR TITLE
[1019] Create frontend URL helper

### DIFF
--- a/ManageCoursesUi.Tests/Controllers/OrganisationControllerTests.cs
+++ b/ManageCoursesUi.Tests/Controllers/OrganisationControllerTests.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ManageCourses.Api.Model;
 using GovUk.Education.ManageCourses.Domain.Models;
 using GovUk.Education.ManageCourses.Ui;
 using GovUk.Education.ManageCourses.Ui.Controllers;
+using GovUk.Education.ManageCourses.Ui.Services;
 using GovUk.Education.ManageCourses.Ui.ViewModels;
 using ManageCoursesUi.Tests.Mocks;
 using Microsoft.AspNetCore.Mvc;
@@ -51,7 +52,9 @@ namespace ManageCoursesUi.Tests
 
             apiMock.Setup(x => x.GetProviderSummary(It.IsAny<string>())).ReturnsAsync(orgs[1]);
 
-            var controller = new OrganisationController(apiMock.Object);
+            var frontendUrlMock = new Mock<IFrontendUrlService>();
+
+            var controller = new OrganisationController(apiMock.Object, frontendUrlMock.Object);
 
             var result = await controller.Show(providerCode);
 
@@ -85,7 +88,9 @@ namespace ManageCoursesUi.Tests
             apiMock.Setup(x => x.GetProviderSummaries())
                 .ReturnsAsync(orgs);
 
-            var controller = new OrganisationController(apiMock.Object);
+            var frontendUrlMock = new Mock<IFrontendUrlService>();
+
+            var controller = new OrganisationController(apiMock.Object, frontendUrlMock.Object);
 
             var result = controller.RequestAccess(providerCode);
 
@@ -117,7 +122,9 @@ namespace ManageCoursesUi.Tests
             apiMock.Setup(x => x.GetProviderSummaries())
                 .ReturnsAsync(orgs);
 
-            var controller = new OrganisationController(apiMock.Object);
+            var frontendUrlMock = new Mock<IFrontendUrlService>();
+
+            var controller = new OrganisationController(apiMock.Object, frontendUrlMock.Object);
             controller.ModelState.AddModelError("you", "failed");
             var result = await controller.RequestAccessPost(providerCode, new RequestAccessViewModel());
 
@@ -140,7 +147,9 @@ namespace ManageCoursesUi.Tests
 
             var tempDataMock = new Mock<ITempDataDictionary>();
 
-            var controller = new OrganisationController(apiMock.Object);
+            var frontendUrlMock = new Mock<IFrontendUrlService>();
+
+            var controller = new OrganisationController(apiMock.Object, frontendUrlMock.Object);
             controller.TempData = tempDataMock.Object;
 
             var result = await controller.RequestAccessPost(providerCode, viewModel);
@@ -216,7 +225,9 @@ namespace ManageCoursesUi.Tests
             apiMock.Setup(x => x.GetProviderEnrichment(providerCode))
                 .ReturnsAsync(ucasProviderEnrichmentGetModel);
 
-            var controller = new OrganisationController(apiMock.Object);
+            var frontendUrlMock = new Mock<IFrontendUrlService>();
+
+            var controller = new OrganisationController(apiMock.Object, frontendUrlMock.Object);
 
             var result = await controller.About(providerCode);
 
@@ -276,7 +287,9 @@ namespace ManageCoursesUi.Tests
                 It.IsAny<string>(),
                 It.IsAny<Object>()));
 
-            var controller = new OrganisationController(apiMock.Object);
+            var frontendUrlMock = new Mock<IFrontendUrlService>();
+
+            var controller = new OrganisationController(apiMock.Object, frontendUrlMock.Object);
 
             controller.ObjectValidator = objectValidator.Object;
 
@@ -339,7 +352,9 @@ namespace ManageCoursesUi.Tests
                 It.IsAny<string>(),
                 It.IsAny<Object>()));
 
-            var controller = new OrganisationController(apiMock.Object);
+            var frontendUrlMock = new Mock<IFrontendUrlService>();
+
+            var controller = new OrganisationController(apiMock.Object, frontendUrlMock.Object);
             controller.ObjectValidator = objectValidator.Object;
 
             controller.TempData = new Mock<ITempDataDictionary>().Object;
@@ -393,7 +408,8 @@ namespace ManageCoursesUi.Tests
 
             apiMock.Setup(x => x.PublishAllCoursesOfProviderToSearchAndCompare(providerCode))
                 .ReturnsAsync(true);
-            var controller = new OrganisationController(apiMock.Object);
+            var frontendUrlMock = new Mock<IFrontendUrlService>();
+            var controller = new OrganisationController(apiMock.Object, frontendUrlMock.Object);
             controller.ObjectValidator = objectValidator.Object;
 
             controller.TempData = new Mock<ITempDataDictionary>().Object;
@@ -475,7 +491,8 @@ namespace ManageCoursesUi.Tests
 
             apiMock.Setup(x => x.PublishAllCoursesOfProviderToSearchAndCompare(providerCode))
                 .ReturnsAsync(true);
-            var controller = new OrganisationControllerMockedValidation(apiMock.Object);
+            var frontendUrlMock = new Mock<IFrontendUrlService>();
+            var controller = new OrganisationControllerMockedValidation(apiMock.Object, frontendUrlMock.Object);
 
             var result = await controller.DetailsPost(providerCode, viewModel);
 
@@ -529,7 +546,9 @@ namespace ManageCoursesUi.Tests
                 It.IsAny<string>(),
                 It.IsAny<Object>()));
 
-            var controller = new OrganisationController(apiMock.Object);
+            var frontendUrlMock = new Mock<IFrontendUrlService>();
+
+            var controller = new OrganisationController(apiMock.Object, frontendUrlMock.Object);
             controller.ObjectValidator = objectValidator.Object;
             controller.TempData = new Mock<ITempDataDictionary>().Object;
 
@@ -604,7 +623,9 @@ namespace ManageCoursesUi.Tests
                 It.IsAny<string>(),
                 It.IsAny<Object>()));
 
-            var controller = new OrganisationController(apiMock.Object);
+            var frontendUrlMock = new Mock<IFrontendUrlService>();
+
+            var controller = new OrganisationController(apiMock.Object, frontendUrlMock.Object);
 
             controller.ObjectValidator = objectValidator.Object;
 

--- a/ManageCoursesUi.Tests/Mocks/OrganisationControllerMockedValidation.cs
+++ b/ManageCoursesUi.Tests/Mocks/OrganisationControllerMockedValidation.cs
@@ -2,6 +2,7 @@
 using GovUk.Education.ManageCourses.Domain.Models;
 using GovUk.Education.ManageCourses.Ui;
 using GovUk.Education.ManageCourses.Ui.Controllers;
+using GovUk.Education.ManageCourses.Ui.Services;
 using GovUk.Education.ManageCourses.Ui.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
@@ -11,7 +12,7 @@ namespace ManageCoursesUi.Tests.Mocks
 {
     public class OrganisationControllerMockedValidation : OrganisationController
     {
-        public OrganisationControllerMockedValidation(IManageApi manageApi) : base(manageApi) { }
+        public OrganisationControllerMockedValidation(IManageApi manageApi, IFrontendUrlService frontendUrlService) : base(manageApi, frontendUrlService) { }
         public override bool TryValidateModel(object model)
         {
             this.ModelState.AddModelError("you", "failed");

--- a/ManageCoursesUi.Tests/Services/FrontendUrlServiceTests.cs
+++ b/ManageCoursesUi.Tests/Services/FrontendUrlServiceTests.cs
@@ -3,6 +3,8 @@ using NUnit.Framework;
 using FluentAssertions;
 using System;
 using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Microsoft.Extensions.Configuration;
 
 namespace ManageCoursesUi.Tests.Services
 {
@@ -12,8 +14,23 @@ namespace ManageCoursesUi.Tests.Services
         [Test]
         public void ReturnsRedirectResultToFrontend()
         {
-            var searchAndCompareUrlService = new FrontendUrlService("http://frontend:123");
+            var configMock = new Mock<IConfiguration>();
+            configMock.SetupGet(c => c["url:frontend"]).Returns("http://frontend:123");
+
+            var searchAndCompareUrlService = new FrontendUrlService(configMock.Object);
+
             searchAndCompareUrlService.RedirectToFrontend("/organisation/47").Url.Should().Be("http://frontend:123/organisation/47");
+        }
+
+        [Test]
+        public void ShouldRedirectOrganisationShow()
+        {
+            var configMock = new Mock<IConfiguration>();
+            configMock.SetupGet(c => c["FEATURE_FRONTEND_ORGANISATION_SHOW"]).Returns("true");
+
+            var searchAndCompareUrlService = new FrontendUrlService(configMock.Object);
+
+            searchAndCompareUrlService.ShouldRedirectOrganisationShow().Should().Be(true);
         }
     }
 }

--- a/ManageCoursesUi.Tests/Services/FrontendUrlServiceTests.cs
+++ b/ManageCoursesUi.Tests/Services/FrontendUrlServiceTests.cs
@@ -15,7 +15,7 @@ namespace ManageCoursesUi.Tests.Services
         public void ReturnsRedirectResultToFrontend()
         {
             var configMock = new Mock<IConfiguration>();
-            configMock.SetupGet(c => c["url:frontend"]).Returns("http://frontend:123");
+            configMock.SetupGet(c => c["ManageCourses:FrontendBaseUrl"]).Returns("http://frontend:123");
 
             var searchAndCompareUrlService = new FrontendUrlService(configMock.Object);
 

--- a/ManageCoursesUi.Tests/Services/FrontendUrlServiceTests.cs
+++ b/ManageCoursesUi.Tests/Services/FrontendUrlServiceTests.cs
@@ -1,0 +1,19 @@
+using GovUk.Education.ManageCourses.Ui.Services;
+using NUnit.Framework;
+using FluentAssertions;
+using System;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ManageCoursesUi.Tests.Services
+{
+    [TestFixture]
+    public class FrontendUrlServiceTests
+    {
+        [Test]
+        public void ReturnsRedirectResultToFrontend()
+        {
+            var searchAndCompareUrlService = new FrontendUrlService("http://frontend:123");
+            searchAndCompareUrlService.RedirectToFrontend("/organisation/47").Url.Should().Be("http://frontend:123/organisation/47");
+        }
+    }
+}

--- a/src/ui/Controllers/OrganisationController.cs
+++ b/src/ui/Controllers/OrganisationController.cs
@@ -8,6 +8,7 @@ using GovUk.Education.ManageCourses.Api.Model;
 using GovUk.Education.ManageCourses.Domain.Models;
 using GovUk.Education.ManageCourses.Ui;
 using GovUk.Education.ManageCourses.Ui.Helpers;
+using GovUk.Education.ManageCourses.Ui.Services;
 using GovUk.Education.ManageCourses.Ui.Utilities;
 using GovUk.Education.ManageCourses.Ui.ViewModels;
 using Microsoft.AspNetCore.Authorization;
@@ -20,10 +21,12 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
     public class OrganisationController : CommonAttributesControllerBase
     {
         private readonly IManageApi _manageApi;
+        private readonly IFrontendUrlService frontendUrlService;
 
-        public OrganisationController(IManageApi manageApi)
+        public OrganisationController(IManageApi manageApi, IFrontendUrlService frontendUrlService)
         {
             _manageApi = manageApi;
+            this.frontendUrlService = frontendUrlService;
         }
 
         [Route("/organisations")]
@@ -40,6 +43,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         [Route("{providerCode}")]
         public async Task<IActionResult> Show(string providerCode)
         {
+            // return frontendUrlService.RedirectToFrontend("/organisation/" + providerCode);
             var ucasProviderEnrichmentGetModel = await _manageApi.GetProviderEnrichment(providerCode);
             var providerCourses = await _manageApi.GetCoursesOfProvider(providerCode);
             var summary = await _manageApi.GetProviderSummary(providerCode);

--- a/src/ui/Controllers/OrganisationController.cs
+++ b/src/ui/Controllers/OrganisationController.cs
@@ -11,6 +11,7 @@ using GovUk.Education.ManageCourses.Ui.Helpers;
 using GovUk.Education.ManageCourses.Ui.Services;
 using GovUk.Education.ManageCourses.Ui.Utilities;
 using GovUk.Education.ManageCourses.Ui.ViewModels;
+using GovUk.Education.SearchAndCompare.UI.Shared.Features;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -43,7 +44,10 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         [Route("{providerCode}")]
         public async Task<IActionResult> Show(string providerCode)
         {
-            // return frontendUrlService.RedirectToFrontend("/organisation/" + providerCode);
+            if (frontendUrlService.ShouldRedirectOrganisationShow())
+            {
+                return frontendUrlService.RedirectToFrontend("/organisation/" + providerCode);
+            }
             var ucasProviderEnrichmentGetModel = await _manageApi.GetProviderEnrichment(providerCode);
             var providerCourses = await _manageApi.GetCoursesOfProvider(providerCode);
             var summary = await _manageApi.GetProviderSummary(providerCode);

--- a/src/ui/Services/FrontendUrlService.cs
+++ b/src/ui/Services/FrontendUrlService.cs
@@ -1,15 +1,23 @@
 using System;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 
 namespace GovUk.Education.ManageCourses.Ui.Services
 {
     public class FrontendUrlService : IFrontendUrlService
     {
         private string frontendBaseUrl;
+        private readonly IConfiguration _configuration;
 
-        public FrontendUrlService(string frontendBaseUrl)
+        public FrontendUrlService(IConfiguration configuration)
         {
-            this.frontendBaseUrl = frontendBaseUrl;
+            _configuration = configuration;
+            this.frontendBaseUrl = _configuration["url:frontend"];
+        }
+
+        public bool ShouldRedirectOrganisationShow()
+        {
+            return _configuration["FEATURE_FRONTEND_ORGANISATION_SHOW"] == "true";
         }
 
         public RedirectResult RedirectToFrontend(string path)

--- a/src/ui/Services/FrontendUrlService.cs
+++ b/src/ui/Services/FrontendUrlService.cs
@@ -12,7 +12,7 @@ namespace GovUk.Education.ManageCourses.Ui.Services
         public FrontendUrlService(IConfiguration configuration)
         {
             _configuration = configuration;
-            this.frontendBaseUrl = _configuration["url:frontend"];
+            this.frontendBaseUrl = _configuration["ManageCourses:FrontendBaseUrl"];
         }
 
         public bool ShouldRedirectOrganisationShow()

--- a/src/ui/Services/FrontendUrlService.cs
+++ b/src/ui/Services/FrontendUrlService.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ManageCourses.Ui.Services
+{
+    public class FrontendUrlService : IFrontendUrlService
+    {
+        private string frontendBaseUrl;
+
+        public FrontendUrlService(string frontendBaseUrl)
+        {
+            this.frontendBaseUrl = frontendBaseUrl;
+        }
+
+        public RedirectResult RedirectToFrontend(string path)
+        {
+            return new RedirectResult(frontendBaseUrl + path);
+        }
+    }
+}

--- a/src/ui/Services/IFrontendUrlService.cs
+++ b/src/ui/Services/IFrontendUrlService.cs
@@ -5,6 +5,7 @@ namespace GovUk.Education.ManageCourses.Ui.Services
 {
     public interface IFrontendUrlService
     {
+        bool ShouldRedirectOrganisationShow();
         RedirectResult RedirectToFrontend(string path);
     }
 }

--- a/src/ui/Services/IFrontendUrlService.cs
+++ b/src/ui/Services/IFrontendUrlService.cs
@@ -1,0 +1,10 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ManageCourses.Ui.Services
+{
+    public interface IFrontendUrlService
+    {
+        RedirectResult RedirectToFrontend(string path);
+    }
+}

--- a/src/ui/Startup.cs
+++ b/src/ui/Startup.cs
@@ -263,6 +263,7 @@ namespace GovUk.Education.ManageCourses.Ui
             });
             services.AddScoped<SearchAndCompare.UI.Shared.Features.IFeatureFlags, SearchAndCompare.UI.Shared.Features.FeatureFlags>();
             services.AddSingleton<ISearchAndCompareUrlService>(x => new SearchAndCompareUrlService(Configuration.GetValue("SearchAndCompare:UiBaseUrl", "")));
+            services.AddSingleton<IFrontendUrlService, FrontendUrlService>();
             services.AddSingleton<IHttpClient>(serviceProvider => {
                 var httpContextAccessor = serviceProvider.GetService<IHttpContextAccessor>();
 

--- a/src/ui/appsettings.Development.json
+++ b/src/ui/appsettings.Development.json
@@ -15,7 +15,8 @@
   },
   "url": {
     "site": "https://localhost:44364",
-    "profile": "https://signin-test-pfl-as.azurewebsites.net"
+    "profile": "https://signin-test-pfl-as.azurewebsites.net",
+    "frontend": "https://localhost:1234"
   },
   "API_URL": "https://bat-dev-manage-courses-api-app.azurewebsites.net/"
 }

--- a/src/ui/appsettings.Development.json
+++ b/src/ui/appsettings.Development.json
@@ -15,8 +15,11 @@
   },
   "url": {
     "site": "https://localhost:44364",
-    "profile": "https://signin-test-pfl-as.azurewebsites.net",
-    "frontend": "https://localhost:1234"
+    "profile": "https://signin-test-pfl-as.azurewebsites.net"
   },
-  "API_URL": "https://bat-dev-manage-courses-api-app.azurewebsites.net/"
+  "ManageCourses": {
+    "FrontendBaseUrl": "https://localhost:3000"
+  },
+  "API_URL": "https://bat-dev-manage-courses-api-app.azurewebsites.net/",
+  "FEATURE_FRONTEND_ORGANISATION_SHOW": "true"
 }


### PR DESCRIPTION
This can be imported and used inside Controllers to redirect users to Frontend for certain controller actions.

A call is added to OrganisationController, wrapper with a feature flag.