### PR TITLE
[1050] Add validation to provider postcode

### DIFF
--- a/ManageCoursesUi.Tests/ViewModels/OrganisationViewModelValidationTests.cs
+++ b/ManageCoursesUi.Tests/ViewModels/OrganisationViewModelValidationTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using GovUk.Education.ManageCourses.Api.Model;
+using GovUk.Education.ManageCourses.Domain.Models;
+using GovUk.Education.ManageCourses.Ui.ViewModels;
+using GovUk.Education.ManageCourses.Ui.ViewModels.Enums;
+using NUnit.Framework;
+
+
+namespace ManageCoursesUi.Tests.ViewModels
+{
+    [TestFixture]
+    public class OrganisationViewModelValidationTests
+    {
+        [Test]
+        public void PostCode_RegularExpression()
+        {
+            var ovm = GetMissingPostCodeModel();
+            ovm.Postcode = "*****";
+            var validationResults = ValidateModel(ovm);
+            validationResults.Should().HaveCount(1);
+            validationResults[0].ErrorMessage.Should().Be("Enter a postcode in the format ‘SW10 1AA‘");
+        }
+
+        [Test]
+        public void PostCode_MaxLength()
+        {
+            var ovm = GetMissingPostCodeModel();
+            ovm.Postcode = "123456789";
+            var validationResults = ValidateModel(ovm);
+            validationResults.Should().HaveCount(1);
+            validationResults[0].ErrorMessage.Should().Be("Postcode is too long. Enter a postcode in the format ‘SW10 1AA’");
+        }
+
+        [Test]
+        public void PostCode_MinLength()
+        {
+            var ovm = GetMissingPostCodeModel();
+            ovm.Postcode = "1";
+            var validationResults = ValidateModel(ovm);
+            validationResults.Should().HaveCount(1);
+            validationResults[0].ErrorMessage.Should().Be("Postcode is too short. Enter a postcode in the format ‘SW10 1AA’");
+        }
+
+
+        [Test]
+        public void PostCode_Required()
+        {
+            var ovm = GetMissingPostCodeModel();
+
+            var validationResults = ValidateModel(ovm);
+            validationResults.Should().HaveCount(1);
+            validationResults[0].ErrorMessage.Should().Be("Enter a postcode in the format ‘SW10 1AA’");
+        }
+
+        private OrganisationViewModel GetMissingPostCodeModel()
+        {
+            return new OrganisationViewModel
+                {
+
+                    TrainWithUs = "TrainWithUs",
+                    TrainWithDisability = "TrainWithDisability",
+                    EmailAddress = "email@example.org",
+                    Telephone = "1234",
+                    Url = "http://example.org",
+                    Addr1 = "Addr1",
+                    Addr3 = "Addr3",
+                    Addr4 = "Addr4",
+                };
+        }
+        private IList<ValidationResult> ValidateModel(object model)
+        {
+            var validationResults = new List<ValidationResult>();
+            var ctx = new ValidationContext(model, null, null);
+            Validator.TryValidateObject(model, ctx, validationResults, true);
+            return validationResults;
+        }
+    }
+}

--- a/ManageCoursesUi.Tests/ViewModels/OrganisationViewModelValidationTests.cs
+++ b/ManageCoursesUi.Tests/ViewModels/OrganisationViewModelValidationTests.cs
@@ -16,6 +16,23 @@ namespace ManageCoursesUi.Tests.ViewModels
     [TestFixture]
     public class OrganisationViewModelValidationTests
     {
+
+        [TestCase("SW10 1AA")]
+        [TestCase("SW101AA")]
+        [TestCase("Sw101Aa")]
+        [TestCase("sw101aa")]
+        [TestCase("sw10 1aa")]
+        [TestCase("s1 1aa")]
+        [TestCase("S1 1AA")]
+        [TestCase("S11AA")]
+        public void PostCode_Valid(string postcode)
+        {
+            var ovm = GetMissingPostCodeModel();
+            ovm.Postcode = postcode;
+            var validationResults = ValidateModel(ovm);
+            validationResults.Should().HaveCount(0);
+        }
+
         [Test]
         public void PostCode_RegularExpression()
         {

--- a/src/ui/ViewModels/OrganisationViewModel.cs
+++ b/src/ui/ViewModels/OrganisationViewModel.cs
@@ -61,15 +61,7 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         [MinLength(7, ErrorMessage = "Postcode is too short. Enter a postcode in the format ‘SW10 1AA’")]
         [MaxLength(8, ErrorMessage = "Postcode is too long. Enter a postcode in the format ‘SW10 1AA’")]
         [Required(ErrorMessage = "Enter a postcode in the format ‘SW10 1AA’")]
-        private string _postcode;
-        public string Postcode
-        {
-          get { return _postcode; }
-          set
-          {
-            _postcode = !string.IsNullOrEmpty( value ) ? value.Trim().ToUpper() : value;
-          }
-        }
+        public string Postcode { get; set; }
 
         public DateTime? LastPublishedTimestampUtc { get; set; }
 

--- a/src/ui/ViewModels/OrganisationViewModel.cs
+++ b/src/ui/ViewModels/OrganisationViewModel.cs
@@ -61,7 +61,15 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         [MinLength(7, ErrorMessage = "Postcode is too short. Enter a postcode in the format ‘SW10 1AA’")]
         [MaxLength(8, ErrorMessage = "Postcode is too long. Enter a postcode in the format ‘SW10 1AA’")]
         [Required(ErrorMessage = "Enter a postcode in the format ‘SW10 1AA’")]
-        public string Postcode { get; set; }
+        private string _postcode;
+        public string Postcode
+        {
+          get { return _postcode; }
+          set
+          {
+            _postcode = !string.IsNullOrEmpty( value ) ? value.Trim().ToUpper() : value;
+          }
+        }
 
         public DateTime? LastPublishedTimestampUtc { get; set; }
 

--- a/src/ui/ViewModels/OrganisationViewModel.cs
+++ b/src/ui/ViewModels/OrganisationViewModel.cs
@@ -58,7 +58,9 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         [Required(ErrorMessage = "Enter your county")]
         public string Addr4 { get; set; }
 
-        [Required(ErrorMessage = "Enter postcode")]
+        [MinLength(7, ErrorMessage = "Postcode is too short. Enter a postcode in the format ‘SW10 1AA’")]
+        [MaxLength(8, ErrorMessage = "Postcode is too long. Enter a postcode in the format ‘SW10 1AA’")]
+        [Required(ErrorMessage = "Enter a postcode in the format ‘SW10 1AA’")]
         public string Postcode { get; set; }
 
         public DateTime? LastPublishedTimestampUtc { get; set; }

--- a/src/ui/ViewModels/OrganisationViewModel.cs
+++ b/src/ui/ViewModels/OrganisationViewModel.cs
@@ -58,6 +58,7 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         [Required(ErrorMessage = "Enter your county")]
         public string Addr4 { get; set; }
 
+        [RegularExpression(@"^[a-zA-Z0-9]+$", ErrorMessage = "Enter a postcode in the format ‘SW10 1AA‘")]
         [MinLength(7, ErrorMessage = "Postcode is too short. Enter a postcode in the format ‘SW10 1AA’")]
         [MaxLength(8, ErrorMessage = "Postcode is too long. Enter a postcode in the format ‘SW10 1AA’")]
         [Required(ErrorMessage = "Enter a postcode in the format ‘SW10 1AA’")]

--- a/src/ui/ViewModels/OrganisationViewModel.cs
+++ b/src/ui/ViewModels/OrganisationViewModel.cs
@@ -59,7 +59,7 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         public string Addr4 { get; set; }
 
         [RegularExpression(@"^[a-zA-Z0-9]+$", ErrorMessage = "Enter a postcode in the format ‘SW10 1AA‘")]
-        [MinLength(7, ErrorMessage = "Postcode is too short. Enter a postcode in the format ‘SW10 1AA’")]
+        [MinLength(5, ErrorMessage = "Postcode is too short. Enter a postcode in the format ‘SW10 1AA’")]
         [MaxLength(8, ErrorMessage = "Postcode is too long. Enter a postcode in the format ‘SW10 1AA’")]
         [Required(ErrorMessage = "Enter a postcode in the format ‘SW10 1AA’")]
         public string Postcode { get; set; }

--- a/src/ui/ViewModels/OrganisationViewModel.cs
+++ b/src/ui/ViewModels/OrganisationViewModel.cs
@@ -58,7 +58,7 @@ namespace GovUk.Education.ManageCourses.Ui.ViewModels
         [Required(ErrorMessage = "Enter your county")]
         public string Addr4 { get; set; }
 
-        [RegularExpression(@"^[a-zA-Z0-9]+$", ErrorMessage = "Enter a postcode in the format ‘SW10 1AA‘")]
+        [RegularExpression(@"^[a-zA-Z0-9 ]+$", ErrorMessage = "Enter a postcode in the format ‘SW10 1AA‘")]
         [MinLength(5, ErrorMessage = "Postcode is too short. Enter a postcode in the format ‘SW10 1AA’")]
         [MaxLength(8, ErrorMessage = "Postcode is too long. Enter a postcode in the format ‘SW10 1AA’")]
         [Required(ErrorMessage = "Enter a postcode in the format ‘SW10 1AA’")]


### PR DESCRIPTION
### Context
Prevent bad postcode data being sent to downstream systems

### Changes proposed in this pull request
- Update postcode missing validation message
- Add minimum length to postcode validation
- Add maximum length to postcode validation

### Guidance to review
- Try to remove the postcode and publish
- Try less than 7 digits and publish
- Try more than 8 digits and publish

e.g. https://localhost:44364/organisation/t92/details
