### PR TITLE
[XXXX] Fix weird dotnet char span issue

### DIFF
--- a/ManageCoursesUi.Tests/Helpers/TestHelper.cs
+++ b/ManageCoursesUi.Tests/Helpers/TestHelper.cs
@@ -105,7 +105,7 @@ namespace ManageCoursesUi.Tests.Helpers
                         {
                             new CourseSite {
                                 Status = "R",
-                                ApplicationsAcceptedFrom = "2018-10-16 00:00:00",
+                                ApplicationsAcceptedFrom = DateTime.Parse("2018-10-16 00:00:00"),
 
                                 Site = new Site
                                 {

--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -433,7 +433,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
 
                         return new SiteViewModel
                         {
-                            ApplicationsAcceptedFrom = courseSite.ApplicationsAcceptedFrom,
+                            ApplicationsAcceptedFrom = courseSite.ApplicationsAcceptedFrom.ToString(),
                             Code = courseSite.Site.Code,
                             LocationName = courseSite.Site.LocationName,
                             Address = address,

--- a/src/ui/Helpers/ViewModelHelpers.cs
+++ b/src/ui/Helpers/ViewModelHelpers.cs
@@ -23,7 +23,7 @@ namespace GovUk.Education.ManageCourses.Ui.Helpers
                 .Select(x => {
                     DateTime? dateResult = null;
                     DateTime date;
-                    if(DateTime.TryParse(x.ApplicationsAcceptedFrom, out date)){
+                    if(DateTime.TryParse(x.ApplicationsAcceptedFrom.ToString(), out date)){
                         dateResult = date;
                     }
                     return dateResult;


### PR DESCRIPTION
Currently, the application is failing to build on CI due to a type mismatch between ApplicationsAcceptedFrom and where it's being passed in. ToString seems to fix it, though I can't say for sure if this breaks anything.

Errors before:

```
Controllers/CourseController.cs(436,56): error CS0029: Cannot implicitly convert type 'System.DateTime?' to 'string' [/home/travis/build/DFE-Digital/manage-courses-ui/src/ui/ManageCoursesUi.csproj]
Helpers/ViewModelHelpers.cs(26,42): error CS1503: Argument 1: cannot convert from 'System.DateTime?' to 'System.ReadOnlySpan<char>' [/home/travis/build/DFE-Digital/manage-courses-ui/src/ui/ManageCoursesUi.csproj]
```
