### PR TITLE
[1360] Remove Information from UCAS in course details

### DIFF
--- a/src/ui/Views/Course/Shared/_CourseDetailsHeaderSection.cshtml
+++ b/src/ui/Views/Course/Shared/_CourseDetailsHeaderSection.cshtml
@@ -18,8 +18,6 @@
     }
 
 } else {
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Information from UCAS</h2>
-
     @if(Model.Course.StatusAsEnum != CourseRunningStatus.Running)
     {
     <div class="govuk-warning-text govuk-warning-text--inline">
@@ -46,6 +44,4 @@
         }
     </p>
     }
-
-    <p class="govuk-body">You can only change this information using <a href="https://update.ucas.co.uk/netupdate2/Welcome.htm">UCAS web-link</a>. Changes will usually appear here within one working day.</p>
 }


### PR DESCRIPTION
We don't need to display this information here anymore, as the enrichments are now being displayed in manage-courses-frontend.