### PR TITLE
[XXXX] Fix course salary page title

### DIFF
--- a/src/ui/Views/Course/Salary.cshtml
+++ b/src/ui/Views/Course/Salary.cshtml
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl">@Model.CourseInfo.Name (@Model.CourseInfo.ProgrammeCode)</span>
-        Course length and fees
+        Course length and salary
       </h1>
       @await Html.PartialAsync("ErrorSummary")
     </div>


### PR DESCRIPTION
### Context
Typo on course salary page

### Changes proposed in this pull request
Fixed typo

### Guidance to review
Salary page should say "salary" and not "fees"
