### PR TITLE
80 enable app service logs

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -118,7 +118,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/80-enable-app-service-logs/templates/",
         "resourceNamePrefix": "[toLower(concat('bat-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "keyvaultCertificateName": "[if(greater(length(parameters('certificateName')),0), parameters('certificateName'), replace(parameters('customHostName'), '.', '-'))]",
         "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",
@@ -194,6 +194,15 @@
                     },
                     "appServicePlanName": {
                         "value": "[variables('appServicePlanName')]"
+                    },
+                    "httpLoggingEnabled": {
+                        "value": true
+                    },
+                    "requestTracingEnabled": {
+                        "value": true
+                    },
+                    "detailedErrorLoggingEnabled": {
+                        "value": true
                     },
                     "appServiceAppSettings": {
                         "value": [

--- a/azure/template.json
+++ b/azure/template.json
@@ -118,7 +118,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/80-enable-app-service-logs/templates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
         "resourceNamePrefix": "[toLower(concat('bat-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "keyvaultCertificateName": "[if(greater(length(parameters('certificateName')),0), parameters('certificateName'), replace(parameters('customHostName'), '.', '-'))]",
         "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",

--- a/azure/template.json
+++ b/azure/template.json
@@ -195,15 +195,6 @@
                     "appServicePlanName": {
                         "value": "[variables('appServicePlanName')]"
                     },
-                    "httpLoggingEnabled": {
-                        "value": true
-                    },
-                    "requestTracingEnabled": {
-                        "value": true
-                    },
-                    "detailedErrorLoggingEnabled": {
-                        "value": true
-                    },
                     "appServiceAppSettings": {
                         "value": [
                             {
@@ -272,6 +263,38 @@
                 "app-service-plan"
             ]
         },
+        {
+            "name": "app-service-logs",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2017-05-10",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'), 'app-service-logs.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appServiceName": {
+                        "value": "[variables('appServiceName')]"
+                    },
+                    "applicationLogsFileSystem": {
+                        "value": "Error"
+                    },
+                    "httpLoggingEnabled": {
+                        "value": true
+                    },
+                    "requestTracingEnabled": {
+                        "value": true
+                    },
+                    "detailedErrorLoggingEnabled": {
+                        "value": true
+                    }
+                }
+            },
+            "dependsOn": [
+                "app-service"
+            ]
+        }, 
         {
             "apiVersion": "2017-05-10",
             "name": "app-insights",


### PR DESCRIPTION
### Context
Enable App Service Logs and will turn on:
Application logging (for 12 hours only)
Web server logging
Detailed error messages
Failed request tracing

### Changes proposed in this pull request
Add a resource deployment to the apps ARM template that references the App Service Log building block.

### Guidance to review
