### PR TITLE
[1705] Redirect legacy course enrichment paths

### DIFF
--- a/ManageCoursesUi.Tests/CourseControllerTests.cs
+++ b/ManageCoursesUi.Tests/CourseControllerTests.cs
@@ -257,39 +257,6 @@ namespace ManageCoursesUi.Tests
         }
 
         [Test]
-        public async Task About()
-        {
-            var manageApi = new Mock<IManageApi>();
-
-            var enrichmentModel = new CourseEnrichmentModel { AboutCourse = "AboutCourse", InterviewProcess = "InterviewProcess", HowSchoolPlacementsWork = "HowSchoolPlacementsWork" };
-            var ucasCourseEnrichmentGetModel = new UcasCourseEnrichmentGetModel { EnrichmentModel = enrichmentModel };
-
-            manageApi.Setup(x => x.GetCourseEnrichment(TestHelper.ProviderCode, TestHelper.TargetedProviderCode)).ReturnsAsync(ucasCourseEnrichmentGetModel);
-
-            var testCourse = new Course() { Name = "Name", CourseCode = "CourseCode" };
-
-            manageApi.Setup(x => x.GetCourse(TestHelper.ProviderCode, TestHelper.TargetedProviderCode)).ReturnsAsync(testCourse);
-
-            var frontendUrlMock = new Mock<IFrontendUrlService>();
-            var controller = new CourseController(manageApi.Object, new SearchAndCompareUrlService("http://www.example.com"), frontendUrlMock.Object);
-            var result = await controller.About(TestHelper.ProviderCode, TestHelper.AccreditingProviderCode, TestHelper.TargetedProviderCode);
-
-            var viewResult = result as ViewResult;
-            Assert.IsNotNull(viewResult);
-
-            var model = viewResult.Model as AboutCourseEnrichmentViewModel;
-
-            Assert.IsNotNull(model);
-
-            Assert.AreEqual(TestHelper.ProviderCode, model.RouteData.ProviderCode);
-            Assert.AreEqual(TestHelper.TargetedProviderCode, model.RouteData.CourseCode);
-
-            Assert.AreEqual(enrichmentModel.AboutCourse, model.AboutCourse);
-            Assert.AreEqual(enrichmentModel.InterviewProcess, model.InterviewProcess);
-            Assert.AreEqual(enrichmentModel.HowSchoolPlacementsWork, model.HowSchoolPlacementsWork);
-        }
-
-        [Test]
         public async Task AboutPost_Invalid()
         {
             var manageApi = new Mock<IManageApi>();
@@ -363,39 +330,6 @@ namespace ManageCoursesUi.Tests
             Assert.AreEqual(TestHelper.TargetedProviderCode, routeValues["courseCode"]);
 
             manageApi.Verify(x => x.SaveCourseEnrichment(TestHelper.ProviderCode, TestHelper.TargetedProviderCode, It.Is<CourseEnrichmentModel>(c => Check(c, viewModel))), Times.Once());
-        }
-
-        [Test]
-        public async Task Requirements()
-        {
-            var manageApi = new Mock<IManageApi>();
-
-            var enrichmentModel = new CourseEnrichmentModel { Qualifications = "Qualifications", PersonalQualities = "PersonalQualities", OtherRequirements = "OtherRequirements" };
-            var ucasCourseEnrichmentGetModel = new UcasCourseEnrichmentGetModel { EnrichmentModel = enrichmentModel };
-
-            manageApi.Setup(x => x.GetCourseEnrichment(TestHelper.ProviderCode, TestHelper.TargetedProviderCode)).ReturnsAsync(ucasCourseEnrichmentGetModel);
-
-            var testCourse = new Course() { Name = "Name", CourseCode = "CourseCode" };
-
-            manageApi.Setup(x => x.GetCourse(TestHelper.ProviderCode, TestHelper.TargetedProviderCode)).ReturnsAsync(testCourse);
-
-            var frontendUrlMock = new Mock<IFrontendUrlService>();
-            var controller = new CourseController(manageApi.Object, new SearchAndCompareUrlService("http://www.example.com"), frontendUrlMock.Object);
-            var result = await controller.Requirements(TestHelper.ProviderCode, TestHelper.AccreditingProviderCode, TestHelper.TargetedProviderCode);
-
-            var viewResult = result as ViewResult;
-            Assert.IsNotNull(viewResult);
-
-            var model = viewResult.Model as CourseRequirementsEnrichmentViewModel;
-
-            Assert.IsNotNull(model);
-
-            Assert.AreEqual(TestHelper.ProviderCode, model.RouteData.ProviderCode);
-            Assert.AreEqual(TestHelper.TargetedProviderCode, model.RouteData.CourseCode);
-
-            Assert.AreEqual(enrichmentModel.Qualifications, model.Qualifications);
-            Assert.AreEqual(enrichmentModel.PersonalQualities, model.PersonalQualities);
-            Assert.AreEqual(enrichmentModel.OtherRequirements, model.OtherRequirements);
         }
 
         [Test]
@@ -478,41 +412,6 @@ namespace ManageCoursesUi.Tests
         }
 
         [Test]
-        public async Task Salary()
-        {
-            var manageApi = new Mock<IManageApi>();
-
-            var enrichmentModel = new CourseEnrichmentModel
-            {
-                CourseLength = null, SalaryDetails = "SalaryDetails"
-            };
-            var ucasCourseEnrichmentGetModel = new UcasCourseEnrichmentGetModel { EnrichmentModel = enrichmentModel };
-
-            manageApi.Setup(x => x.GetCourseEnrichment(TestHelper.ProviderCode, TestHelper.TargetedProviderCode)).ReturnsAsync(ucasCourseEnrichmentGetModel);
-
-            var testCourse = new Course() { Name = "Name", CourseCode = "CourseCode" };
-
-            manageApi.Setup(x => x.GetCourse(TestHelper.ProviderCode, TestHelper.TargetedProviderCode)).ReturnsAsync(testCourse);
-
-            var frontendUrlMock = new Mock<IFrontendUrlService>();
-            var controller = new CourseController(manageApi.Object, new SearchAndCompareUrlService("http://www.example.com"), frontendUrlMock.Object);
-            var result = await controller.Salary(TestHelper.ProviderCode, TestHelper.AccreditingProviderCode, TestHelper.TargetedProviderCode);
-
-            var viewResult = result as ViewResult;
-            Assert.IsNotNull(viewResult);
-
-            var model = viewResult.Model as CourseSalaryEnrichmentViewModel;
-
-            Assert.IsNotNull(model);
-
-            Assert.AreEqual(TestHelper.ProviderCode, model.RouteData.ProviderCode);
-            Assert.AreEqual(TestHelper.TargetedProviderCode, model.RouteData.CourseCode);
-
-            Assert.AreEqual(enrichmentModel.CourseLength, model.CourseLength);
-            Assert.AreEqual(enrichmentModel.SalaryDetails, model.SalaryDetails);
-        }
-
-        [Test]
         public async Task SalaryPost_Invalid()
         {
             var manageApi = new Mock<IManageApi>();
@@ -589,44 +488,6 @@ namespace ManageCoursesUi.Tests
             Assert.AreEqual(TestHelper.TargetedProviderCode, routeValues["courseCode"]);
 
             manageApi.Verify(x => x.SaveCourseEnrichment(TestHelper.ProviderCode, TestHelper.TargetedProviderCode, It.Is<CourseEnrichmentModel>(c => Check(c, viewModel))), Times.Once());
-        }
-
-        [Test]
-        public async Task Fees()
-        {
-            var manageApi = new Mock<IManageApi>();
-
-            var enrichmentModel = new CourseEnrichmentModel
-            {
-                FeeUkEu = 123.45m, FeeInternational = 543.21m, FeeDetails = "FeeDetails", CourseLength = null, FinancialSupport = "FinancialSupport"
-            };
-            var ucasCourseEnrichmentGetModel = new UcasCourseEnrichmentGetModel { EnrichmentModel = enrichmentModel };
-
-            manageApi.Setup(x => x.GetCourseEnrichment(TestHelper.ProviderCode, TestHelper.TargetedProviderCode)).ReturnsAsync(ucasCourseEnrichmentGetModel);
-
-            var testCourse = new Course() { Name = "Name", CourseCode = "CourseCode" };
-
-            manageApi.Setup(x => x.GetCourse(TestHelper.ProviderCode, TestHelper.TargetedProviderCode)).ReturnsAsync(testCourse);
-
-            var frontendUrlMock = new Mock<IFrontendUrlService>();
-            var controller = new CourseController(manageApi.Object, new SearchAndCompareUrlService("http://www.example.com"), frontendUrlMock.Object);
-            var result = await controller.Fees(TestHelper.ProviderCode, TestHelper.AccreditingProviderCode, TestHelper.TargetedProviderCode);
-
-            var viewResult = result as ViewResult;
-            Assert.IsNotNull(viewResult);
-
-            var model = viewResult.Model as CourseFeesEnrichmentViewModel;
-
-            Assert.IsNotNull(model);
-
-            Assert.AreEqual(TestHelper.ProviderCode, model.RouteData.ProviderCode);
-            Assert.AreEqual(TestHelper.TargetedProviderCode, model.RouteData.CourseCode);
-
-            Assert.AreEqual(enrichmentModel.CourseLength, model.CourseLength);
-            Assert.AreEqual(enrichmentModel.FeeDetails, model.FeeDetails);
-            Assert.AreEqual(enrichmentModel.FeeInternational.GetFeeValue(), model.FeeInternational);
-            Assert.AreEqual(enrichmentModel.FeeUkEu.GetFeeValue(), model.FeeUkEu);
-            Assert.AreEqual(enrichmentModel.FinancialSupport, model.FinancialSupport);
         }
 
         [Test]

--- a/src/ui/Controllers/CourseController.cs
+++ b/src/ui/Controllers/CourseController.cs
@@ -34,26 +34,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         [Route("{providerCode}/course/{accreditingProviderCode=self}/{courseCode}")]
         public async Task<IActionResult> Show(string providerCode, string accreditingProviderCode, string courseCode)
         {
-            Validate(providerCode, accreditingProviderCode, courseCode);
-
-            var orgsList = await _manageApi.GetProviderSummaries();
-            var userOrganisations = orgsList.ToList();
-            var multipleOrganisations = userOrganisations.Count() > 1;
-            var org = userOrganisations.ToList().FirstOrDefault(x => providerCode.ToLower() == x.ProviderCode.ToLower());
-
-            if (org == null) { return NotFound(); }
-
-            var course = await _manageApi.GetCourse(providerCode, courseCode);
-
-            if (course == null) return NotFound();
-
-            var ucasCourseEnrichmentGetModel = await _manageApi.GetCourseEnrichment(providerCode, courseCode);
-
-            var routeData = GetCourseRouteDataViewModel(providerCode, courseCode);
-
-            var viewModel = LoadViewModel(org, course, multipleOrganisations, ucasCourseEnrichmentGetModel, routeData);
-
-            return View("Show", viewModel);
+          return frontendUrlService.RedirectToFrontend("/organisations/" + providerCode + "/courses/" + courseCode);
         }
 
         [HttpPost]
@@ -95,59 +76,14 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         [Route("{providerCode}/course/{accreditingProviderCode=self}/{courseCode}/preview")]
         public IActionResult Preview(string providerCode, string accreditingProviderCode, string courseCode)
         {
-            var course = _manageApi.GetSearchAndCompareCourse(providerCode, courseCode).Result;
-            if (course == null)
-            {
-                return NotFound();
-            }
-
-            return View(new SearchAndCompare.UI.Shared.ViewModels.CourseDetailsViewModel
-            {
-                AboutYourOrgLink = Url.Action("About", "Organisation", new { providerCode = providerCode }),
-                PreviewMode = true,
-                Course = course,
-                Finance = new FinanceViewModel(course, new FeeCaps())
-            });
+          return frontendUrlService.RedirectToFrontend("/organisations/" + providerCode + "/courses/" + courseCode + "/preview");
         }
 
         [HttpGet]
         [Route("{providerCode}/course/{accreditingProviderCode=self}/{courseCode}/about")]
         public async Task<IActionResult> About(string providerCode, string accreditingProviderCode, string courseCode, string copyFrom = null)
         {
-            var courseDetails = await _manageApi.GetCourse(providerCode, courseCode);
-            var ucasCourseEnrichmentGetModel = await _manageApi.GetCourseEnrichment(providerCode, courseCode);
-
-            var routeData = GetCourseRouteDataViewModel(providerCode, courseCode);
-            var courseInfo = new CourseInfoViewModel { ProgrammeCode = courseDetails.CourseCode, Name = courseDetails.Name };
-
-            var enrichmentModel = ucasCourseEnrichmentGetModel?.EnrichmentModel ?? new CourseEnrichmentModel();
-
-            var model = new AboutCourseEnrichmentViewModel
-            {
-                AboutCourse = enrichmentModel?.AboutCourse,
-                InterviewProcess = enrichmentModel?.InterviewProcess,
-                HowSchoolPlacementsWork = enrichmentModel?.HowSchoolPlacementsWork,
-                RouteData = routeData,
-                CourseInfo = courseInfo
-            };
-
-            await LoadCopyableCoursesIntoViewBag(providerCode, courseCode);
-
-            if (!string.IsNullOrEmpty(copyFrom))
-            {
-                copyFrom = copyFrom.ToUpper();
-                var copiedEnrichment = await _manageApi.GetCourseEnrichment(providerCode, copyFrom);
-                ViewBag.CopiedFrom = new CourseInfoViewModel
-                {
-                    ProgrammeCode = copyFrom,
-                    Name = (ViewBag.CopyableCourses as IEnumerable<Domain.Models.Course>).SingleOrDefault(x => x.CourseCode == copyFrom)?.Name
-                };
-
-                ViewBag.CopiedFields = model.CopyFrom(copiedEnrichment?.EnrichmentModel);
-            }
-
-
-            return View(model);
+          return frontendUrlService.RedirectToFrontend("/organisations/" + providerCode + "/courses/" + courseCode + "/about");
         }
 
         private async Task LoadCopyableCoursesIntoViewBag(string providerCode, string courseCode)
@@ -186,38 +122,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         [Route("{providerCode}/course/{accreditingProviderCode=self}/{courseCode}/requirements")]
         public async Task<IActionResult> Requirements(string providerCode, string accreditingProviderCode, string courseCode, string copyFrom = null)
         {
-            var courseDetails = await _manageApi.GetCourse(providerCode, courseCode);
-            var ucasCourseEnrichmentGetModel = await _manageApi.GetCourseEnrichment(providerCode, courseCode);
-            var routeData = GetCourseRouteDataViewModel(providerCode, courseCode);
-            var courseInfo = new CourseInfoViewModel { ProgrammeCode = courseDetails.CourseCode, Name = courseDetails.Name };
-
-            var enrichmentModel = ucasCourseEnrichmentGetModel?.EnrichmentModel ?? new CourseEnrichmentModel();
-
-            var model = new CourseRequirementsEnrichmentViewModel
-            {
-                Qualifications = enrichmentModel?.Qualifications,
-                PersonalQualities = enrichmentModel?.PersonalQualities,
-                OtherRequirements = enrichmentModel?.OtherRequirements,
-                RouteData = routeData,
-                CourseInfo = courseInfo
-            };
-
-            await LoadCopyableCoursesIntoViewBag(providerCode, courseCode);
-
-            if (!string.IsNullOrEmpty(copyFrom))
-            {
-                copyFrom = copyFrom.ToUpper();
-                var copiedEnrichment = await _manageApi.GetCourseEnrichment(providerCode, copyFrom);
-                ViewBag.CopiedFrom = new CourseInfoViewModel
-                {
-                    ProgrammeCode = copyFrom,
-                    Name = (ViewBag.CopyableCourses as IEnumerable<Domain.Models.Course>).SingleOrDefault(x => x.CourseCode == copyFrom)?.Name
-                };
-
-                ViewBag.CopiedFields = model.CopyFrom(copiedEnrichment?.EnrichmentModel);
-            }
-
-            return View(model);
+          return frontendUrlService.RedirectToFrontend("/organisations/" + providerCode + "/courses/" + courseCode + "/requirements");
         }
 
         [HttpPost]
@@ -247,38 +152,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         [Route("{providerCode}/course/{accreditingProviderCode=self}/{courseCode}/salary")]
         public async Task<IActionResult> Salary(string providerCode, string accreditingProviderCode, string courseCode, string copyFrom = null)
         {
-            var courseDetails = await _manageApi.GetCourse(providerCode, courseCode);
-            var ucasCourseEnrichmentGetModel = await _manageApi.GetCourseEnrichment(providerCode, courseCode);
-            var routeData = GetCourseRouteDataViewModel(providerCode, courseCode);
-            var courseInfo = new CourseInfoViewModel { ProgrammeCode = courseDetails.CourseCode, Name = courseDetails.Name };
-
-            var enrichmentModel = ucasCourseEnrichmentGetModel?.EnrichmentModel ?? new CourseEnrichmentModel();
-
-            var model = new CourseSalaryEnrichmentViewModel
-            {
-                CourseLength = enrichmentModel?.CourseLength.GetCourseLength(),
-                CourseLengthInput = enrichmentModel.CourseLength.GetCourseLengthInput(),
-                SalaryDetails = enrichmentModel?.SalaryDetails,
-                RouteData = routeData,
-                CourseInfo = courseInfo
-            };
-
-            await LoadCopyableCoursesIntoViewBag(providerCode, courseCode);
-
-            if (!string.IsNullOrEmpty(copyFrom))
-            {
-                copyFrom = copyFrom.ToUpper();
-                var copiedEnrichment = await _manageApi.GetCourseEnrichment(providerCode, copyFrom);
-                ViewBag.CopiedFrom = new CourseInfoViewModel
-                {
-                    ProgrammeCode = copyFrom,
-                    Name = (ViewBag.CopyableCourses as IEnumerable<Domain.Models.Course>).SingleOrDefault(x => x.CourseCode == copyFrom)?.Name
-                };
-
-                ViewBag.CopiedFields = model.CopyFrom(copiedEnrichment?.EnrichmentModel);
-            }
-
-            return View(model);
+          return frontendUrlService.RedirectToFrontend("/organisations/" + providerCode + "/courses/" + courseCode + "/salary");
         }
 
         [HttpPost]
@@ -306,41 +180,7 @@ namespace GovUk.Education.ManageCourses.Ui.Controllers
         [Route("{providerCode}/course/{accreditingProviderCode=self}/{courseCode}/fees-and-length")]
         public async Task<IActionResult> Fees(string providerCode, string accreditingProviderCode, string courseCode, string copyFrom = null)
         {
-            var courseDetails = await _manageApi.GetCourse(providerCode, courseCode);
-            var ucasCourseEnrichmentGetModel = await _manageApi.GetCourseEnrichment(providerCode, courseCode);
-            var routeData = GetCourseRouteDataViewModel(providerCode, courseCode);
-            var courseInfo = new CourseInfoViewModel { ProgrammeCode = courseDetails.CourseCode, Name = courseDetails.Name };
-
-            var enrichmentModel = ucasCourseEnrichmentGetModel?.EnrichmentModel ?? new CourseEnrichmentModel();
-
-            var model = new CourseFeesEnrichmentViewModel
-            {
-                CourseLength = enrichmentModel?.CourseLength.GetCourseLength(),
-                CourseLengthInput = enrichmentModel.CourseLength.GetCourseLengthInput(),
-                FeeUkEu = enrichmentModel?.FeeUkEu.GetFeeValue(),
-                FeeInternational = enrichmentModel?.FeeInternational.GetFeeValue(),
-                FeeDetails = enrichmentModel?.FeeDetails,
-                FinancialSupport = enrichmentModel?.FinancialSupport,
-                RouteData = routeData,
-                CourseInfo = courseInfo
-            };
-
-            await LoadCopyableCoursesIntoViewBag(providerCode, courseCode);
-
-            if (!string.IsNullOrEmpty(copyFrom))
-            {
-                copyFrom = copyFrom.ToUpper();
-                var copiedEnrichment = await _manageApi.GetCourseEnrichment(providerCode, copyFrom);
-                ViewBag.CopiedFrom = new CourseInfoViewModel
-                {
-                    ProgrammeCode = copyFrom,
-                    Name = (ViewBag.CopyableCourses as IEnumerable<Domain.Models.Course>).SingleOrDefault(x => x.CourseCode == copyFrom)?.Name
-                };
-
-                ViewBag.CopiedFields = model.CopyFrom(copiedEnrichment?.EnrichmentModel);
-            }
-
-            return View(model);
+          return frontendUrlService.RedirectToFrontend("/organisations/" + providerCode + "/courses/" + courseCode + "/fees");
         }
 
         [HttpPost]


### PR DESCRIPTION
### Context
Course enrichments are now on the rails frontend app

### Changes proposed in this pull request
Redirect `{about, requirements, salary, fees, preview}`

### Guidance to review
Example - `https://localhost:44364/organisation/T92/course/self/X130/fees`